### PR TITLE
Docs preview

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,38 @@
+name: Deploy PR previews
+concurrency: preview-${{ github.ref }}
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+    branches:
+      - "*"
+
+permissions:
+  contents: write
+
+env:
+  BASE_URL: ${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}
+  URL: https://${{ github.repository_owner }}.github.io/
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'deploy preview')
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+      - run: yarn install --frozen-lockfile && yarn build
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: build
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,9 +11,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -25,6 +23,9 @@ concurrency:
 defaults:
   run:
     shell: bash
+
+env:
+  URL: https://docs.rancher-turtles.com/
 
 jobs:
   build:
@@ -44,20 +45,10 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build website
-        run: yarn build          
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        run: yarn build
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: ./build
-
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+          force: false
+          folder: build # The folder the action should deploy.
+          clean-exclude: pr-preview/

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -6,6 +6,7 @@ sidebar_position: 0
 
 Welcome to the Rancher Turtles documentation site. 
 
+
 ## Getting Started
 
 Please checkout out [getting started guide](./getting-started/intro).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ const config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'rancher-sandbox', // Usually your GitHub org/user name.
-  projectName: 'rancher-turtles-docs', // Usually your repo name.
+  projectName: 'rancher-turtles-docs', // Usuaqglly your repo name.
   scripts: [{ src: 'https://plausible.io/js/plausible.js', async: true, defer: true, 'data-domain': 'rancher-sandbox.github.io' }],
 
   onBrokenLinks: 'throw',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,10 +11,10 @@ const config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://docs.rancher-turtles.com',
+  url: process.env.URL ? `${process.env.URL.toLowerCase()}` : "https://docs.rancher-turtles.com/",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: process.env.BASE_URL ? `${process.env.BASE_URL}/` : "/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Using `rossjrw/pr-preview-action` to preview docs deployment on each PR.

After this PR is merged, each open PR labeled with `deploy preview` will get a preview in gh-pages branch. All deployments are stored on `gh-pages` branch.