### PR TITLE
doc: Remove 'sandbox' mentions in docs and configurations

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -14,14 +14,14 @@ sidebar_position: 2
 
 ## Create a local development environment
 
-1. Clone the [Rancher Turtles](https://github.com/rancher-sandbox/rancher-turtles) repository locally
+1. Clone the [Rancher Turtles](https://github.com/rancher/turtles) repository locally
 
 2. Create **tilt-settings.yaml**:
 
 ```yaml
 {
     "k8s_context": "k3d-rancher-test",
-    "default_registry": "ghcr.io/rancher-turtles-dev",
+    "default_registry": "ghcr.io/turtles-dev",
     "debug": {
         "turtles": {
             "continue": true,
@@ -50,7 +50,7 @@ ngrok http https://localhost:10000
 
 ## What happens when you run `make dev-env`?
 
-1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher-sandbox/rancher-turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
+1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher/turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
 1. [Cert manager](https://cert-manager.io/) is installed on the cluster, which is a requirement for running `Rancher turtes` extension.
 1. `clusterctl` is used to bootstrap CAPI components onto the cluster, and a default configuration includes: core Cluster API controller, Kubeadm bootstrap and control plane providers, Docker infrastructure provider.
 1. `Rancher manager` is installed using helm.

--- a/docs/contributing/guidelines.md
+++ b/docs/contributing/guidelines.md
@@ -21,7 +21,7 @@ sidebar_position: 1
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-Thank you for taking the time to contribute to Rancher CAPI extension [projects](https://github.com/rancher-sandbox?q=rancher-turtles&type=all&language=&sort=) :heart:
+Thank you for taking the time to contribute to Rancher CAPI extension [projects](https://github.com/rancher?q=turtles&type=all&language=&sort=) :heart:
 
 Improvements to all areas of the project; from code, to documentation;
 from bug reports to feature design and UI enhancement are gratefully welcome.
@@ -56,12 +56,12 @@ If you’re a new to the project and want to help, but don’t know where to sta
 
 1. Interested in helping to improve:
 
-- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
-    [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles/labels/help-wanted).
-    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
-- extension UI? Take a look at [`open`](https://github.com/rancher-sandbox/rancher-turtles-ui/issues) or
-    [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles-ui/labels/help-wanted).
-- maybe, user-docs? :nerd_face: Then, jump straight into [`open` issues](https://github.com/rancher-sandbox/rancher-turtles-docs/issues) in the docs repository.
+- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
+    [`help wanted` issues](https://github.com/rancher/turtles/labels/help-wanted).
+    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
+- extension UI? Take a look at [`open`](https://github.com/rancher/capi-ui-extension) or
+    [`help wanted` issues](https://github.com/rancher/capi-ui-extension/labels/help-wanted).
+- maybe, user-docs? :nerd_face: Then, jump straight into [`open` issues](https://github.com/rancher/turtles-docs/issues) in the docs repository.
 
 ## Opening Issues
 
@@ -100,7 +100,7 @@ If you are here to ask for help or request some new behaviour, this
 is the section for you. We have curated a set of issues for anyone who simply
 wants to build up their open-source cred :muscle:.
 
-- Issues labelled [`good first issues`](https://github.com/search?q=org%3Agithub%2Francher-sandbox+repo%3Arancher-sandbox%2Francher-turtles+repo%3Arancher-sandbox%2Francher-turtles-ui+repo%3Arancher-sandbox%2Francher-turtles-docs+is%3Aopen+label%3A%22good+first+issue%22+&type=issues&ref=advsearch)
+- Issues labelled [`good first issues`](https://github.com/search?q=org%3Agithub%2Francher+repo%3Arancher%2Fturtles+repo%3Arancher%2Fcapi-ui-extension+repo%3Arancher%2Fturtles-docs+is%3Aopen+label%3A%22good+first+issue%22+&type=issues&ref=advsearch)
   should be accessible to folks new to the repos, as well as to open source in general.
 
   These issues should present a low/non-existent barrier to entry with a thorough description,
@@ -116,7 +116,7 @@ wants to build up their open-source cred :muscle:.
 
   See more on [asking for help](#asking-for-help) below!
 
-- [`help wanted` issues](https://github.com/search?q=org%3Agithub%2Francher-sandbox+repo%3Arancher-sandbox%2Francher-turtles+repo%3Arancher-sandbox%2Francher-turtles-ui+repo%3Arancher-sandbox%2Francher-turtles-docs+is%3Aopen+label%3A%22help+wanted%22+&type=issues&ref=advsearch)
+- [`help wanted` issues](https://github.com/search?q=org%3Agithub%2Francher+repo%3Arancher%2Fturtles+repo%3Arancher%2Fcapi-ui-extension+repo%3Arancher%2Fturtles-docs+is%3Aopen+label%3A%22help+wanted%22+&type=issues&ref=advsearch)
   are for those a little more familiar with the code base, but should still be accessible enough
   to newcomers.
 
@@ -207,7 +207,7 @@ The core team regularly processes incoming issues. There may be some delay over 
 
 Every issue will be assigned a `priority/<x>` label. The levels of priorities are:
 
-- [`critical-urgent`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
+- [`critical-urgent`](https://github.com/rancher/turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
   If an issue labelled `critical` is not assigned or being actively worked on,
   someone is expected to drop what they're doing immediately to work on it.
   This usually means the core team, but community members are welcome to claim
@@ -216,13 +216,13 @@ Every issue will be assigned a `priority/<x>` label. The levels of priorities ar
   they will be paired with a core team-member to manage the tracking, communication and release of any fix
   as well as to assume responsibility of all progess._
 
-- [`important-soon`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
+- [`important-soon`](https://github.com/rancher/turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
   Ideally something should be delivered in time for the next release.
 
-- [`important-longterm`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
+- [`important-longterm`](https://github.com/rancher/turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
   staffed and/or may require multiple releases to complete.
 
-- [`backlog`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
+- [`backlog`](https://github.com/rancher/turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
   but we may not have anyone available to work on it right now or in the immediate future.
   PRs are still very welcome, although it might take a while to get them reviewed if
   reviewers are fully occupied with higher priority issues, for example immediately before a release.
@@ -231,11 +231,11 @@ These priority categories have been inspired by [the Kubernetes contributing gui
 
 Other labels include:
 
-- [`adr-required`](https://github.com/rancher-sandbox/rancher-turtles/labels/adr-required):
+- [`adr-required`](https://github.com/rancher/turtles/labels/adr-required):
   Indicates that the issue or PR contains a decision that needs to be documented in a [ADR](#adrs-architectural-decision-records) _before_
   it can be worked on.
 
-- [`needs-investigation`](https://github.com/rancher-sandbox/rancher-turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
+- [`needs-investigation`](https://github.com/rancher/turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
   or to understand and implement a solution. This could be because the issue opener did
   not provide enough relevant information, or because more in-depth research is required
   before work can begin.
@@ -254,7 +254,7 @@ Submissions which do not meet standards will be de-prioritised for review.
 ## ADRs (Architectural Decision Records)
 
 :::note
-Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher-sandbox/rancher-turtles) repository.
+Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher/turtles) repository.
 :::
 
 Any impactful decisions to the architecture, design, development and behaviour
@@ -267,7 +267,7 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
 
 ### Process
 
-1. Start a new [discussion](https://github.com/rancher-sandbox/rancher-turtles/discussions/new?category=adr) using the `ADR` category.
+1. Start a new [discussion](https://github.com/rancher/turtles/discussions/new?category=adr) using the `ADR` category.
 
 1. Choose an appropriate clear and concise title (e.g. `ADR: Implement X in Go`).
 
@@ -276,10 +276,10 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
   any areas which you would like the reviewers to pay attention to, or those on which
   you would specifically like an opinion.
 
-1. Tag in the [maintainers](https://github.com/rancher-sandbox/rancher-turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
+1. Tag in the [maintainers](https://github.com/rancher/turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
   participate and weigh in on the decision and its consequences.
 
-1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr).
+1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher/turtles/blob/main/docs/adr).
   Copy and complete the [template][adr-template];
     - Increment the file number by one
     - Set the status as "Accepted"
@@ -287,5 +287,5 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
     - Summarise the decision and consequences from the discussion thread
     - Link back to the discussion from the ADR doc
 
-[user-docs]: https://rancher-sandbox.github.io/rancher-turtles-docs/
-[adr-template]: https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr/0000-template.md
+[user-docs]: https://rancher.github.io/turtles-docs/
+[adr-template]: https://github.com/rancher/turtles/blob/main/docs/adr/0000-template.md

--- a/docs/getting-started/install_turtles_operator.md
+++ b/docs/getting-started/install_turtles_operator.md
@@ -52,7 +52,7 @@ This operation could take a few minutes and, after installing, you can take some
 :::note
 - If `cert-manager` is already available in the cluster, you can disable its installation as a Rancher Turtles dependency to avoid conflicts:
 `--set cluster-api-operator.cert-manager.enabled=false`
-- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher-sandbox/rancher-turtles/releases).
+- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher/turtles/releases).
 :::
 
 This is the basic, recommended configuration, which manages the creation of a secret containing the required CAPI feature flags (`CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` enabled) in the core provider namespace. These feature flags are required to enable additional Cluster API functionality.

--- a/docs/reference-guides/rancher-turtles-chart/values.md
+++ b/docs/reference-guides/rancher-turtles-chart/values.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 # Chart configuration
 
 :::tip
-For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher-sandbox/rancher-turtles).
+For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher/turtles).
 :::
 
 ## Rancher Turtles values

--- a/docs/tasks/capi-operator/capiprovider_resource.md
+++ b/docs/tasks/capi-operator/capiprovider_resource.md
@@ -10,7 +10,7 @@ The `CAPIProvider` resource allows managing Cluster API Operator manifests in a 
 
 Every field provided by the upstream CAPI Operator resource for the desired `spec.type` is also available in the spec of the `CAPIProvider` resouce. Feel free to refer to upstream configuration [guides](https://cluster-api-operator.sigs.k8s.io/03_topics/02_configuration/) for advanced scenarios.
 
-[ARD](https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr/0007-rancher-turtles-public-api.md)
+[ARD](https://github.com/rancher/turtles/blob/main/docs/adr/0007-rancher-turtles-public-api.md)
 
 ## Usage
 
@@ -55,7 +55,7 @@ The key fields in the `CAPIProvider` spec are:
 - `features` - Enabled provider features
 - `variables` - Variables is a map of environment variables to add to the content of the `configSecret`
 
-Full documentation on the CAPIProvider resource - [here](https://doc.crds.dev/github.com/rancher-sandbox/rancher-turtles/turtles-capi.cattle.io/CAPIProvider/v1alpha1@v0.5.0).
+Full documentation on the CAPIProvider resource - [here](https://doc.crds.dev/github.com/rancher/turtles/turtles-capi.cattle.io/CAPIProvider/v1alpha1@v0.5.0).
 
 ## Deletion
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,9 +18,9 @@ const config = {
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'rancher-sandbox', // Usually your GitHub org/user name.
-  projectName: 'rancher-turtles-docs', // Usually your repo name.
-  scripts: [{ src: 'https://plausible.io/js/plausible.js', async: true, defer: true, 'data-domain': 'rancher-sandbox.github.io' }],
+  organizationName: 'rancher', // Usually your GitHub org/user name.
+  projectName: 'turtles-docs', // Usually your repo name.
+  scripts: [{ src: 'https://plausible.io/js/plausible.js', async: true, defer: true, 'data-domain': 'rancher.github.io' }],
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -49,14 +49,14 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/rancher-sandbox/rancher-turtles-docs/tree/main/docs/',
+            'https://github.com/rancher/turtles-docs/tree/main/docs/',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/rancher-sandbox/rancher-turtles-docs/tree/main/docs/',
+            'https://github.com/rancher/turtles-docs/tree/main/docs/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
@@ -90,7 +90,7 @@ const config = {
             dropdownActiveClassDisabled: true,
           },
           {
-            href: 'https://github.com/rancher-sandbox/rancher-turtles-docs',
+            href: 'https://github.com/rancher/turtles-docs',
             label: 'GitHub',
             position: 'right',
           },


### PR DESCRIPTION
Old https://github.com/rancher-sandbox/rancher-turtles-docs repo was moved to new https://github.com/rancher/turtles-docs locations, hence, this PR updates all mentions to old URL in docs and docusaurus configurations