### PR TITLE
Replace all references to old repo and old chart location

### DIFF
--- a/versioned_docs/version-0.1/contributing/development.md
+++ b/versioned_docs/version-0.1/contributing/development.md
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 ## Create a local development environment
 
-1. Clone the [Rancher Turtles](https://github.com/rancher-sandbox/rancher-turtles) repository locally
+1. Clone the [Rancher Turtles](https://github.com/rancher/turtles) repository locally
 
 2. Create **tilt-settings.yaml**:
 
@@ -50,7 +50,7 @@ ngrok http https://localhost:10000
 
 ## What happens when you run `make dev-env`?
 
-1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher-sandbox/rancher-turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
+1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher/turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
 1. [Cert manager](https://cert-manager.io/) is installed on the cluster, which is a requirement for running `Rancher turtes` extension.
 1. `clusterctl` is used to bootstrap CAPI components onto the cluster, and a default configuration includes: core Cluster API controller, Kubeadm bootstrap and control plane providers, Docker infrastructure provider.
 1. `Rancher manager` is installed using helm.

--- a/versioned_docs/version-0.1/contributing/guidelines.md
+++ b/versioned_docs/version-0.1/contributing/guidelines.md
@@ -21,7 +21,7 @@ sidebar_position: 1
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-Thank you for taking the time to contribute to Rancher CAPI extension [projects](https://github.com/rancher-sandbox?q=rancher-turtles&type=all&language=&sort=) :heart:
+Thank you for taking the time to contribute to Rancher CAPI extension [projects](https://github.com/rancher?q=turtles&type=all&language=&sort=) :heart:
 
 Improvements to all areas of the project; from code, to documentation;
 from bug reports to feature design and UI enhancement are gratefully welcome.
@@ -56,9 +56,9 @@ If you’re a new to the project and want to help, but don’t know where to sta
 
 1. Interested in helping to improve:
 
-- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
-    [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles/labels/help-wanted).
-    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
+- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
+    [`help wanted` issues](https://github.com/rancher/turtles/labels/help-wanted).
+    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
 - extension UI? Take a look at [`open`](https://github.com/rancher-sandbox/rancher-turtles-ui/issues) or
     [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles-ui/labels/help-wanted).
 - maybe, user-docs? :nerd_face: Then, jump straight into [`open` issues](https://github.com/rancher-sandbox/rancher-turtles-docs/issues) in the docs repository.
@@ -207,7 +207,7 @@ The core team regularly processes incoming issues. There may be some delay over 
 
 Every issue will be assigned a `priority/<x>` label. The levels of priorities are:
 
-- [`critical-urgent`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
+- [`critical-urgent`](https://github.com/rancher/turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
   If an issue labelled `critical` is not assigned or being actively worked on,
   someone is expected to drop what they're doing immediately to work on it.
   This usually means the core team, but community members are welcome to claim
@@ -216,13 +216,13 @@ Every issue will be assigned a `priority/<x>` label. The levels of priorities ar
   they will be paired with a core team-member to manage the tracking, communication and release of any fix
   as well as to assume responsibility of all progess._
 
-- [`important-soon`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
+- [`important-soon`](https://github.com/rancher/turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
   Ideally something should be delivered in time for the next release.
 
-- [`important-longterm`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
+- [`important-longterm`](https://github.com/rancher/turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
   staffed and/or may require multiple releases to complete.
 
-- [`backlog`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
+- [`backlog`](https://github.com/rancher/turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
   but we may not have anyone available to work on it right now or in the immediate future.
   PRs are still very welcome, although it might take a while to get them reviewed if
   reviewers are fully occupied with higher priority issues, for example immediately before a release.
@@ -231,11 +231,11 @@ These priority categories have been inspired by [the Kubernetes contributing gui
 
 Other labels include:
 
-- [`adr-required`](https://github.com/rancher-sandbox/rancher-turtles/labels/adr-required):
+- [`adr-required`](https://github.com/rancher/turtles/labels/adr-required):
   Indicates that the issue or PR contains a decision that needs to be documented in a [ADR](#adrs-architectural-decision-records) _before_
   it can be worked on.
 
-- [`needs-investigation`](https://github.com/rancher-sandbox/rancher-turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
+- [`needs-investigation`](https://github.com/rancher/turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
   or to understand and implement a solution. This could be because the issue opener did
   not provide enough relevant information, or because more in-depth research is required
   before work can begin.
@@ -254,7 +254,7 @@ Submissions which do not meet standards will be de-prioritised for review.
 ## ADRs (Architectural Decision Records)
 
 :::note
-Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher-sandbox/rancher-turtles) repository.
+Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher/turtles) repository.
 :::
 
 Any impactful decisions to the architecture, design, development and behaviour
@@ -267,7 +267,7 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
 
 ### Process
 
-1. Start a new [discussion](https://github.com/rancher-sandbox/rancher-turtles/discussions/new?category=adr) using the `ADR` category.
+1. Start a new [discussion](https://github.com/rancher/turtles/discussions/new?category=adr) using the `ADR` category.
 
 1. Choose an appropriate clear and concise title (e.g. `ADR: Implement X in Go`).
 
@@ -276,10 +276,10 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
   any areas which you would like the reviewers to pay attention to, or those on which
   you would specifically like an opinion.
 
-1. Tag in the [maintainers](https://github.com/rancher-sandbox/rancher-turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
+1. Tag in the [maintainers](https://github.com/rancher/turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
   participate and weigh in on the decision and its consequences.
 
-1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr).
+1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher/turtles/blob/main/docs/adr).
   Copy and complete the [template][adr-template];
     - Increment the file number by one
     - Set the status as "Accepted"
@@ -287,5 +287,5 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
     - Summarise the decision and consequences from the discussion thread
     - Link back to the discussion from the ADR doc
 
-[user-docs]: https://rancher-sandbox.github.io/rancher-turtles-docs/
-[adr-template]: https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr/0000-template.md
+[user-docs]: https://rancher.github.io/turtles-docs/
+[adr-template]: https://github.com/rancher/turtles/blob/main/docs/adr/0000-template.md

--- a/versioned_docs/version-0.1/getting-started/install_turtles_operator.md
+++ b/versioned_docs/version-0.1/getting-started/install_turtles_operator.md
@@ -11,7 +11,7 @@ This section walks through different installation options for the Rancher Turtle
 A `rancher-turtles` chart repository should be added first:
 
 ```bash
-helm repo add turtles https://charts.rancher-turtles.com/
+helm repo add turtles https://rancher.github.io/turtles
 helm repo update
 ```
 
@@ -28,7 +28,7 @@ helm install rancher-turtles turtles/rancher-turtles --version <chart-version>
 :::note
 - If `cert-manager` is already available in the cluster, you can disable its installation as a Rancher Turtles dependency to avoid conflicts:
 `--set cluster-api-operator.cert-manager.enabled=false`
-- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher-sandbox/rancher-turtles/releases).
+- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher/turtles/releases).
 :::
 
 This is the basic, recommended configuration, which manages the creation of a secret containing the required feature flags (`CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` enabled) in the core provider namespace.
@@ -104,7 +104,7 @@ For information on deployment options, refer to [Deployment Scenarios](../refere
 The recommended path of installation for the operator is by using `Helm`. To install it in the cluster, a chart repository should be added first:
 
 ```bash
-helm repo add turtles https://charts.rancher-turtles.com/
+helm repo add turtles https://rancher.github.io/turtles
 helm repo update
 ```
 and then it can be installed into the `rancher-turtles-system` namespace with:

--- a/versioned_docs/version-0.2.0/contributing/development.md
+++ b/versioned_docs/version-0.2.0/contributing/development.md
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 ## Create a local development environment
 
-1. Clone the [Rancher Turtles](https://github.com/rancher-sandbox/rancher-turtles) repository locally
+1. Clone the [Rancher Turtles](https://github.com/rancher/turtles) repository locally
 
 2. Create **tilt-settings.yaml**:
 
@@ -50,7 +50,7 @@ ngrok http https://localhost:10000
 
 ## What happens when you run `make dev-env`?
 
-1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher-sandbox/rancher-turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
+1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher/turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
 1. [Cert manager](https://cert-manager.io/) is installed on the cluster, which is a requirement for running `Rancher turtes` extension.
 1. `clusterctl` is used to bootstrap CAPI components onto the cluster, and a default configuration includes: core Cluster API controller, Kubeadm bootstrap and control plane providers, Docker infrastructure provider.
 1. `Rancher manager` is installed using helm.

--- a/versioned_docs/version-0.2.0/contributing/guidelines.md
+++ b/versioned_docs/version-0.2.0/contributing/guidelines.md
@@ -56,9 +56,9 @@ If you’re a new to the project and want to help, but don’t know where to sta
 
 1. Interested in helping to improve:
 
-- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
-    [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles/labels/help-wanted).
-    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
+- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
+    [`help wanted` issues](https://github.com/rancher/turtles/labels/help-wanted).
+    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
 - extension UI? Take a look at [`open`](https://github.com/rancher-sandbox/rancher-turtles-ui/issues) or
     [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles-ui/labels/help-wanted).
 - maybe, user-docs? :nerd_face: Then, jump straight into [`open` issues](https://github.com/rancher-sandbox/rancher-turtles-docs/issues) in the docs repository.
@@ -207,7 +207,7 @@ The core team regularly processes incoming issues. There may be some delay over 
 
 Every issue will be assigned a `priority/<x>` label. The levels of priorities are:
 
-- [`critical-urgent`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
+- [`critical-urgent`](https://github.com/rancher/turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
   If an issue labelled `critical` is not assigned or being actively worked on,
   someone is expected to drop what they're doing immediately to work on it.
   This usually means the core team, but community members are welcome to claim
@@ -216,13 +216,13 @@ Every issue will be assigned a `priority/<x>` label. The levels of priorities ar
   they will be paired with a core team-member to manage the tracking, communication and release of any fix
   as well as to assume responsibility of all progess._
 
-- [`important-soon`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
+- [`important-soon`](https://github.com/rancher/turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
   Ideally something should be delivered in time for the next release.
 
-- [`important-longterm`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
+- [`important-longterm`](https://github.com/rancher/turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
   staffed and/or may require multiple releases to complete.
 
-- [`backlog`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
+- [`backlog`](https://github.com/rancher/turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
   but we may not have anyone available to work on it right now or in the immediate future.
   PRs are still very welcome, although it might take a while to get them reviewed if
   reviewers are fully occupied with higher priority issues, for example immediately before a release.
@@ -231,11 +231,11 @@ These priority categories have been inspired by [the Kubernetes contributing gui
 
 Other labels include:
 
-- [`adr-required`](https://github.com/rancher-sandbox/rancher-turtles/labels/adr-required):
+- [`adr-required`](https://github.com/rancher/turtles/labels/adr-required):
   Indicates that the issue or PR contains a decision that needs to be documented in a [ADR](#adrs-architectural-decision-records) _before_
   it can be worked on.
 
-- [`needs-investigation`](https://github.com/rancher-sandbox/rancher-turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
+- [`needs-investigation`](https://github.com/rancher/turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
   or to understand and implement a solution. This could be because the issue opener did
   not provide enough relevant information, or because more in-depth research is required
   before work can begin.
@@ -254,7 +254,7 @@ Submissions which do not meet standards will be de-prioritised for review.
 ## ADRs (Architectural Decision Records)
 
 :::note
-Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher-sandbox/rancher-turtles) repository.
+Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher/turtles) repository.
 :::
 
 Any impactful decisions to the architecture, design, development and behaviour
@@ -267,7 +267,7 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
 
 ### Process
 
-1. Start a new [discussion](https://github.com/rancher-sandbox/rancher-turtles/discussions/new?category=adr) using the `ADR` category.
+1. Start a new [discussion](https://github.com/rancher/turtles/discussions/new?category=adr) using the `ADR` category.
 
 1. Choose an appropriate clear and concise title (e.g. `ADR: Implement X in Go`).
 
@@ -276,10 +276,10 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
   any areas which you would like the reviewers to pay attention to, or those on which
   you would specifically like an opinion.
 
-1. Tag in the [maintainers](https://github.com/rancher-sandbox/rancher-turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
+1. Tag in the [maintainers](https://github.com/rancher/turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
   participate and weigh in on the decision and its consequences.
 
-1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr).
+1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher/turtles/blob/main/docs/adr).
   Copy and complete the [template][adr-template];
     - Increment the file number by one
     - Set the status as "Accepted"
@@ -288,4 +288,4 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
     - Link back to the discussion from the ADR doc
 
 [user-docs]: https://rancher-sandbox.github.io/rancher-turtles-docs/
-[adr-template]: https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr/0000-template.md
+[adr-template]: https://github.com/rancher/turtles/blob/main/docs/adr/0000-template.md

--- a/versioned_docs/version-0.2.0/getting-started/install_turtles_operator.md
+++ b/versioned_docs/version-0.2.0/getting-started/install_turtles_operator.md
@@ -19,7 +19,7 @@ To simplify setting up Rancher for installing Rancher Turtles, the official Ranc
 A `rancher-turtles` chart repository should be added first:
 
 ```bash
-helm repo add turtles https://charts.rancher-turtles.com/
+helm repo add turtles https://rancher.github.io/turtles
 helm repo update
 ```
 
@@ -36,7 +36,7 @@ helm install rancher-turtles turtles/rancher-turtles --version v0.2.0
 :::note
 - If `cert-manager` is already available in the cluster, you can disable its installation as a Rancher Turtles dependency to avoid conflicts:
 `--set cluster-api-operator.cert-manager.enabled=false`
-- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher-sandbox/rancher-turtles/releases).
+- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher/turtles/releases).
 :::
 
 This is the basic, recommended configuration, which manages the creation of a secret containing the required feature flags (`CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` enabled) in the core provider namespace.
@@ -83,7 +83,7 @@ For information on deployment options, refer to [Deployment Scenarios](../refere
 The recommended path of installation for the operator is by using `Helm`. To install it in the cluster, a chart repository should be added first:
 
 ```bash
-helm repo add turtles https://charts.rancher-turtles.com/
+helm repo add turtles https://rancher.github.io/turtles
 helm repo update
 ```
 and then it can be installed into the `rancher-turtles-system` namespace with:

--- a/versioned_docs/version-0.2.0/reference-guides/rancher-turtles-chart/values.md
+++ b/versioned_docs/version-0.2.0/reference-guides/rancher-turtles-chart/values.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 # Chart configuration
 
 :::tip
-For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher-sandbox/rancher-turtles).
+For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher/turtles).
 :::
 
 ## Rancher Turtles values

--- a/versioned_docs/version-0.3/contributing/development.md
+++ b/versioned_docs/version-0.3/contributing/development.md
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 ## Create a local development environment
 
-1. Clone the [Rancher Turtles](https://github.com/rancher-sandbox/rancher-turtles) repository locally
+1. Clone the [Rancher Turtles](https://github.com/rancher/turtles) repository locally
 
 2. Create **tilt-settings.yaml**:
 
@@ -50,7 +50,7 @@ ngrok http https://localhost:10000
 
 ## What happens when you run `make dev-env`?
 
-1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher-sandbox/rancher-turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
+1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher/turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
 1. [Cert manager](https://cert-manager.io/) is installed on the cluster, which is a requirement for running `Rancher turtes` extension.
 1. `clusterctl` is used to bootstrap CAPI components onto the cluster, and a default configuration includes: core Cluster API controller, Kubeadm bootstrap and control plane providers, Docker infrastructure provider.
 1. `Rancher manager` is installed using helm.

--- a/versioned_docs/version-0.3/contributing/guidelines.md
+++ b/versioned_docs/version-0.3/contributing/guidelines.md
@@ -56,9 +56,9 @@ If you’re a new to the project and want to help, but don’t know where to sta
 
 1. Interested in helping to improve:
 
-- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
-    [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles/labels/help-wanted).
-    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
+- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
+    [`help wanted` issues](https://github.com/rancher/turtles/labels/help-wanted).
+    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
 - extension UI? Take a look at [`open`](https://github.com/rancher-sandbox/rancher-turtles-ui/issues) or
     [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles-ui/labels/help-wanted).
 - maybe, user-docs? :nerd_face: Then, jump straight into [`open` issues](https://github.com/rancher-sandbox/rancher-turtles-docs/issues) in the docs repository.
@@ -207,7 +207,7 @@ The core team regularly processes incoming issues. There may be some delay over 
 
 Every issue will be assigned a `priority/<x>` label. The levels of priorities are:
 
-- [`critical-urgent`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
+- [`critical-urgent`](https://github.com/rancher/turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
   If an issue labelled `critical` is not assigned or being actively worked on,
   someone is expected to drop what they're doing immediately to work on it.
   This usually means the core team, but community members are welcome to claim
@@ -216,13 +216,13 @@ Every issue will be assigned a `priority/<x>` label. The levels of priorities ar
   they will be paired with a core team-member to manage the tracking, communication and release of any fix
   as well as to assume responsibility of all progess._
 
-- [`important-soon`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
+- [`important-soon`](https://github.com/rancher/turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
   Ideally something should be delivered in time for the next release.
 
-- [`important-longterm`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
+- [`important-longterm`](https://github.com/rancher/turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
   staffed and/or may require multiple releases to complete.
 
-- [`backlog`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
+- [`backlog`](https://github.com/rancher/turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
   but we may not have anyone available to work on it right now or in the immediate future.
   PRs are still very welcome, although it might take a while to get them reviewed if
   reviewers are fully occupied with higher priority issues, for example immediately before a release.
@@ -231,11 +231,11 @@ These priority categories have been inspired by [the Kubernetes contributing gui
 
 Other labels include:
 
-- [`adr-required`](https://github.com/rancher-sandbox/rancher-turtles/labels/adr-required):
+- [`adr-required`](https://github.com/rancher/turtles/labels/adr-required):
   Indicates that the issue or PR contains a decision that needs to be documented in a [ADR](#adrs-architectural-decision-records) _before_
   it can be worked on.
 
-- [`needs-investigation`](https://github.com/rancher-sandbox/rancher-turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
+- [`needs-investigation`](https://github.com/rancher/turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
   or to understand and implement a solution. This could be because the issue opener did
   not provide enough relevant information, or because more in-depth research is required
   before work can begin.
@@ -254,7 +254,7 @@ Submissions which do not meet standards will be de-prioritised for review.
 ## ADRs (Architectural Decision Records)
 
 :::note
-Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher-sandbox/rancher-turtles) repository.
+Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher/turtles) repository.
 :::
 
 Any impactful decisions to the architecture, design, development and behaviour
@@ -267,7 +267,7 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
 
 ### Process
 
-1. Start a new [discussion](https://github.com/rancher-sandbox/rancher-turtles/discussions/new?category=adr) using the `ADR` category.
+1. Start a new [discussion](https://github.com/rancher/turtles/discussions/new?category=adr) using the `ADR` category.
 
 1. Choose an appropriate clear and concise title (e.g. `ADR: Implement X in Go`).
 
@@ -276,10 +276,10 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
   any areas which you would like the reviewers to pay attention to, or those on which
   you would specifically like an opinion.
 
-1. Tag in the [maintainers](https://github.com/rancher-sandbox/rancher-turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
+1. Tag in the [maintainers](https://github.com/rancher/turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
   participate and weigh in on the decision and its consequences.
 
-1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr).
+1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher/turtles/blob/main/docs/adr).
   Copy and complete the [template][adr-template];
     - Increment the file number by one
     - Set the status as "Accepted"
@@ -288,4 +288,4 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
     - Link back to the discussion from the ADR doc
 
 [user-docs]: https://rancher-sandbox.github.io/rancher-turtles-docs/
-[adr-template]: https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr/0000-template.md
+[adr-template]: https://github.com/rancher/turtles/blob/main/docs/adr/0000-template.md

--- a/versioned_docs/version-0.3/getting-started/install_turtles_operator.md
+++ b/versioned_docs/version-0.3/getting-started/install_turtles_operator.md
@@ -19,7 +19,7 @@ To simplify setting up Rancher for installing Rancher Turtles, the official Ranc
 A `rancher-turtles` chart repository should be added first:
 
 ```bash
-helm repo add turtles https://charts.rancher-turtles.com/
+helm repo add turtles https://rancher.github.io/turtles
 helm repo update
 ```
 
@@ -36,7 +36,7 @@ helm install rancher-turtles turtles/rancher-turtles --version v0.2.0
 :::note
 - If `cert-manager` is already available in the cluster, you can disable its installation as a Rancher Turtles dependency to avoid conflicts:
 `--set cluster-api-operator.cert-manager.enabled=false`
-- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher-sandbox/rancher-turtles/releases).
+- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher/turtles/releases).
 :::
 
 This is the basic, recommended configuration, which manages the creation of a secret containing the required feature flags (`CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` enabled) in the core provider namespace.
@@ -83,7 +83,7 @@ For information on deployment options, refer to [Deployment Scenarios](../refere
 The recommended path of installation for the operator is by using `Helm`. To install it in the cluster, a chart repository should be added first:
 
 ```bash
-helm repo add turtles https://charts.rancher-turtles.com/
+helm repo add turtles https://rancher.github.io/turtles
 helm repo update
 ```
 and then it can be installed into the `rancher-turtles-system` namespace with:

--- a/versioned_docs/version-0.3/reference-guides/rancher-turtles-chart/values.md
+++ b/versioned_docs/version-0.3/reference-guides/rancher-turtles-chart/values.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 # Chart configuration
 
 :::tip
-For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher-sandbox/rancher-turtles).
+For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher/turtles).
 :::
 
 ## Rancher Turtles values

--- a/versioned_docs/version-0.4/contributing/development.md
+++ b/versioned_docs/version-0.4/contributing/development.md
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 ## Create a local development environment
 
-1. Clone the [Rancher Turtles](https://github.com/rancher-sandbox/rancher-turtles) repository locally
+1. Clone the [Rancher Turtles](https://github.com/rancher/turtles) repository locally
 
 2. Create **tilt-settings.yaml**:
 
@@ -50,7 +50,7 @@ ngrok http https://localhost:10000
 
 ## What happens when you run `make dev-env`?
 
-1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher-sandbox/rancher-turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
+1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher/turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
 1. [Cert manager](https://cert-manager.io/) is installed on the cluster, which is a requirement for running `Rancher turtes` extension.
 1. `clusterctl` is used to bootstrap CAPI components onto the cluster, and a default configuration includes: core Cluster API controller, Kubeadm bootstrap and control plane providers, Docker infrastructure provider.
 1. `Rancher manager` is installed using helm.

--- a/versioned_docs/version-0.4/contributing/guidelines.md
+++ b/versioned_docs/version-0.4/contributing/guidelines.md
@@ -56,9 +56,9 @@ If you’re a new to the project and want to help, but don’t know where to sta
 
 1. Interested in helping to improve:
 
-- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
-    [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles/labels/help-wanted).
-    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
+- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
+    [`help wanted` issues](https://github.com/rancher/turtles/labels/help-wanted).
+    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
 - extension UI? Take a look at [`open`](https://github.com/rancher-sandbox/rancher-turtles-ui/issues) or
     [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles-ui/labels/help-wanted).
 - maybe, user-docs? :nerd_face: Then, jump straight into [`open` issues](https://github.com/rancher-sandbox/rancher-turtles-docs/issues) in the docs repository.
@@ -207,7 +207,7 @@ The core team regularly processes incoming issues. There may be some delay over 
 
 Every issue will be assigned a `priority/<x>` label. The levels of priorities are:
 
-- [`critical-urgent`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
+- [`critical-urgent`](https://github.com/rancher/turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
   If an issue labelled `critical` is not assigned or being actively worked on,
   someone is expected to drop what they're doing immediately to work on it.
   This usually means the core team, but community members are welcome to claim
@@ -216,13 +216,13 @@ Every issue will be assigned a `priority/<x>` label. The levels of priorities ar
   they will be paired with a core team-member to manage the tracking, communication and release of any fix
   as well as to assume responsibility of all progess._
 
-- [`important-soon`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
+- [`important-soon`](https://github.com/rancher/turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
   Ideally something should be delivered in time for the next release.
 
-- [`important-longterm`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
+- [`important-longterm`](https://github.com/rancher/turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
   staffed and/or may require multiple releases to complete.
 
-- [`backlog`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
+- [`backlog`](https://github.com/rancher/turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
   but we may not have anyone available to work on it right now or in the immediate future.
   PRs are still very welcome, although it might take a while to get them reviewed if
   reviewers are fully occupied with higher priority issues, for example immediately before a release.
@@ -231,11 +231,11 @@ These priority categories have been inspired by [the Kubernetes contributing gui
 
 Other labels include:
 
-- [`adr-required`](https://github.com/rancher-sandbox/rancher-turtles/labels/adr-required):
+- [`adr-required`](https://github.com/rancher/turtles/labels/adr-required):
   Indicates that the issue or PR contains a decision that needs to be documented in a [ADR](#adrs-architectural-decision-records) _before_
   it can be worked on.
 
-- [`needs-investigation`](https://github.com/rancher-sandbox/rancher-turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
+- [`needs-investigation`](https://github.com/rancher/turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
   or to understand and implement a solution. This could be because the issue opener did
   not provide enough relevant information, or because more in-depth research is required
   before work can begin.
@@ -254,7 +254,7 @@ Submissions which do not meet standards will be de-prioritised for review.
 ## ADRs (Architectural Decision Records)
 
 :::note
-Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher-sandbox/rancher-turtles) repository.
+Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher/turtles) repository.
 :::
 
 Any impactful decisions to the architecture, design, development and behaviour
@@ -267,7 +267,7 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
 
 ### Process
 
-1. Start a new [discussion](https://github.com/rancher-sandbox/rancher-turtles/discussions/new?category=adr) using the `ADR` category.
+1. Start a new [discussion](https://github.com/rancher/turtles/discussions/new?category=adr) using the `ADR` category.
 
 1. Choose an appropriate clear and concise title (e.g. `ADR: Implement X in Go`).
 
@@ -276,10 +276,10 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
   any areas which you would like the reviewers to pay attention to, or those on which
   you would specifically like an opinion.
 
-1. Tag in the [maintainers](https://github.com/rancher-sandbox/rancher-turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
+1. Tag in the [maintainers](https://github.com/rancher/turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
   participate and weigh in on the decision and its consequences.
 
-1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr).
+1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher/turtles/blob/main/docs/adr).
   Copy and complete the [template][adr-template];
     - Increment the file number by one
     - Set the status as "Accepted"
@@ -288,4 +288,4 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
     - Link back to the discussion from the ADR doc
 
 [user-docs]: https://rancher-sandbox.github.io/rancher-turtles-docs/
-[adr-template]: https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr/0000-template.md
+[adr-template]: https://github.com/rancher/turtles/blob/main/docs/adr/0000-template.md

--- a/versioned_docs/version-0.4/getting-started/install_turtles_operator.md
+++ b/versioned_docs/version-0.4/getting-started/install_turtles_operator.md
@@ -19,7 +19,7 @@ To simplify setting up Rancher for installing Rancher Turtles, the official Ranc
 A `rancher-turtles` chart repository should be added first:
 
 ```bash
-helm repo add turtles https://charts.rancher-turtles.com/
+helm repo add turtles https://rancher.github.io/turtles
 helm repo update
 ```
 
@@ -36,7 +36,7 @@ helm install rancher-turtles turtles/rancher-turtles --version v0.4.0 \
 :::note
 - If `cert-manager` is already available in the cluster, you can disable its installation as a Rancher Turtles dependency to avoid conflicts:
 `--set cluster-api-operator.cert-manager.enabled=false`
-- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher-sandbox/rancher-turtles/releases).
+- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher/turtles/releases).
 :::
 
 This is the basic, recommended configuration, which manages the creation of a secret containing the required feature flags (`CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` enabled) in the core provider namespace.
@@ -82,7 +82,7 @@ For information on deployment options, refer to [Deployment Scenarios](../refere
 The recommended path of installation for the operator is by using `Helm`. To install it in the cluster, a chart repository should be added first:
 
 ```bash
-helm repo add turtles https://charts.rancher-turtles.com/
+helm repo add turtles https://rancher.github.io/turtles
 helm repo update
 ```
 and then it can be installed into the `rancher-turtles-system` namespace with:

--- a/versioned_docs/version-0.4/reference-guides/rancher-turtles-chart/values.md
+++ b/versioned_docs/version-0.4/reference-guides/rancher-turtles-chart/values.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 # Chart configuration
 
 :::tip
-For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher-sandbox/rancher-turtles).
+For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher/turtles).
 :::
 
 ## Rancher Turtles values

--- a/versioned_docs/version-0.4/tasks/capi-operator/capiprovider_resource.md
+++ b/versioned_docs/version-0.4/tasks/capi-operator/capiprovider_resource.md
@@ -8,7 +8,7 @@ The `CAPIProvider` resource allows managing Cluster API Operator manifests in a 
 
 `CAPIProvider` follows a GitOps model - the spec fields are declarative user inputs. The controller only updates status.
 
-[ARD](https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr/0007-rancher-turtles-public-api.md)
+[ARD](https://github.com/rancher/turtles/blob/main/docs/adr/0007-rancher-turtles-public-api.md)
 
 ## Usage
 
@@ -53,7 +53,7 @@ The key fields in the `CAPIProvider` spec are:
 - `features` - Enabled provider features
 - `variables` - Variables is a map of environment variables to add to the content of the `configSecret`
 
-Full documentation on the CAPIProvider resource - [here](https://doc.crds.dev/github.com/rancher-sandbox/rancher-turtles/turtles-capi.cattle.io/CAPIProvider/v1alpha1@v0.4.0).
+Full documentation on the CAPIProvider resource - [here](https://doc.crds.dev/github.com/rancher/turtles/turtles-capi.cattle.io/CAPIProvider/v1alpha1@v0.4.0).
 
 ## Deletion
 

--- a/versioned_docs/version-0.5/contributing/development.md
+++ b/versioned_docs/version-0.5/contributing/development.md
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 ## Create a local development environment
 
-1. Clone the [Rancher Turtles](https://github.com/rancher-sandbox/rancher-turtles) repository locally
+1. Clone the [Rancher Turtles](https://github.com/rancher/turtles) repository locally
 
 2. Create **tilt-settings.yaml**:
 
@@ -50,7 +50,7 @@ ngrok http https://localhost:10000
 
 ## What happens when you run `make dev-env`?
 
-1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher-sandbox/rancher-turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
+1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher/turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
 1. [Cert manager](https://cert-manager.io/) is installed on the cluster, which is a requirement for running `Rancher turtes` extension.
 1. `clusterctl` is used to bootstrap CAPI components onto the cluster, and a default configuration includes: core Cluster API controller, Kubeadm bootstrap and control plane providers, Docker infrastructure provider.
 1. `Rancher manager` is installed using helm.

--- a/versioned_docs/version-0.5/contributing/guidelines.md
+++ b/versioned_docs/version-0.5/contributing/guidelines.md
@@ -56,9 +56,9 @@ If you’re a new to the project and want to help, but don’t know where to sta
 
 1. Interested in helping to improve:
 
-- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
-    [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles/labels/help-wanted).
-    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher-sandbox/rancher-turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
+- Rancher CAPI extension backend? Chime in on [`bugs`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Fbug+) or
+    [`help wanted` issues](https://github.com/rancher/turtles/labels/help-wanted).
+    If you are seeking to take on a bigger challenge or a more experienced contributor, check out [`feature requests`](https://github.com/rancher/turtles/issues?q=is%3Aopen+is%3Aissue+label%3Akind%2Ffeature).
 - extension UI? Take a look at [`open`](https://github.com/rancher-sandbox/rancher-turtles-ui/issues) or
     [`help wanted` issues](https://github.com/rancher-sandbox/rancher-turtles-ui/labels/help-wanted).
 - maybe, user-docs? :nerd_face: Then, jump straight into [`open` issues](https://github.com/rancher-sandbox/rancher-turtles-docs/issues) in the docs repository.
@@ -207,7 +207,7 @@ The core team regularly processes incoming issues. There may be some delay over 
 
 Every issue will be assigned a `priority/<x>` label. The levels of priorities are:
 
-- [`critical-urgent`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
+- [`critical-urgent`](https://github.com/rancher/turtles/labels/priority%2Fcritical-urgent): These are time sensitive issues which should be picked up immediately.
   If an issue labelled `critical` is not assigned or being actively worked on,
   someone is expected to drop what they're doing immediately to work on it.
   This usually means the core team, but community members are welcome to claim
@@ -216,13 +216,13 @@ Every issue will be assigned a `priority/<x>` label. The levels of priorities ar
   they will be paired with a core team-member to manage the tracking, communication and release of any fix
   as well as to assume responsibility of all progess._
 
-- [`important-soon`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
+- [`important-soon`](https://github.com/rancher/turtles/labels/priority%2Fimportant-soon): Must be assigned as soon as capacity becomes available.
   Ideally something should be delivered in time for the next release.
 
-- [`important-longterm`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
+- [`important-longterm`](https://github.com/rancher/turtles/labels/priority%2Fimportant-longterm): Important over the long term, but may not be currently
   staffed and/or may require multiple releases to complete.
 
-- [`backlog`](https://github.com/rancher-sandbox/rancher-turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
+- [`backlog`](https://github.com/rancher/turtles/labels/priority%2Fbacklog): There appears to be general agreement that this would be good to have,
   but we may not have anyone available to work on it right now or in the immediate future.
   PRs are still very welcome, although it might take a while to get them reviewed if
   reviewers are fully occupied with higher priority issues, for example immediately before a release.
@@ -231,11 +231,11 @@ These priority categories have been inspired by [the Kubernetes contributing gui
 
 Other labels include:
 
-- [`adr-required`](https://github.com/rancher-sandbox/rancher-turtles/labels/adr-required):
+- [`adr-required`](https://github.com/rancher/turtles/labels/adr-required):
   Indicates that the issue or PR contains a decision that needs to be documented in a [ADR](#adrs-architectural-decision-records) _before_
   it can be worked on.
 
-- [`needs-investigation`](https://github.com/rancher-sandbox/rancher-turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
+- [`needs-investigation`](https://github.com/rancher/turtles/labels/needs-investigation):  There is currently insufficient information to either categorize properly,
   or to understand and implement a solution. This could be because the issue opener did
   not provide enough relevant information, or because more in-depth research is required
   before work can begin.
@@ -254,7 +254,7 @@ Submissions which do not meet standards will be de-prioritised for review.
 ## ADRs (Architectural Decision Records)
 
 :::note
-Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher-sandbox/rancher-turtles) repository.
+Please feel free to skip [this](#adrs-architectural-decision-records) and [sub-section](#process) below, since they are only relevant to the [rancher-turtles](https://github.com/rancher/turtles) repository.
 :::
 
 Any impactful decisions to the architecture, design, development and behaviour
@@ -267,7 +267,7 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
 
 ### Process
 
-1. Start a new [discussion](https://github.com/rancher-sandbox/rancher-turtles/discussions/new?category=adr) using the `ADR` category.
+1. Start a new [discussion](https://github.com/rancher/turtles/discussions/new?category=adr) using the `ADR` category.
 
 1. Choose an appropriate clear and concise title (e.g. `ADR: Implement X in Go`).
 
@@ -276,10 +276,10 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
   any areas which you would like the reviewers to pay attention to, or those on which
   you would specifically like an opinion.
 
-1. Tag in the [maintainers](https://github.com/rancher-sandbox/rancher-turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
+1. Tag in the [maintainers](https://github.com/rancher/turtles/blob/main/CODEOWNERS) as the "Deciders", and invite them to
   participate and weigh in on the decision and its consequences.
 
-1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr).
+1. Once a decision has been made, open a PR adding a new ADR to the [directory](https://github.com/rancher/turtles/blob/main/docs/adr).
   Copy and complete the [template][adr-template];
     - Increment the file number by one
     - Set the status as "Accepted"
@@ -288,4 +288,4 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
     - Link back to the discussion from the ADR doc
 
 [user-docs]: https://rancher-sandbox.github.io/rancher-turtles-docs/
-[adr-template]: https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr/0000-template.md
+[adr-template]: https://github.com/rancher/turtles/blob/main/docs/adr/0000-template.md

--- a/versioned_docs/version-0.5/getting-started/install_turtles_operator.md
+++ b/versioned_docs/version-0.5/getting-started/install_turtles_operator.md
@@ -36,7 +36,7 @@ helm install rancher-turtles turtles/rancher-turtles --version v0.5.0 \
 :::note
 - If `cert-manager` is already available in the cluster, you can disable its installation as a Rancher Turtles dependency to avoid conflicts:
 `--set cluster-api-operator.cert-manager.enabled=false`
-- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher-sandbox/rancher-turtles/releases).
+- For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher/turtles/releases).
 :::
 
 This is the basic, recommended configuration, which manages the creation of a secret containing the required feature flags (`CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` enabled) in the core provider namespace.
@@ -82,7 +82,7 @@ For information on deployment options, refer to [Deployment Scenarios](../refere
 The recommended path of installation for the operator is by using `Helm`. To install it in the cluster, a chart repository should be added first:
 
 ```bash
-helm repo add turtles https://charts.rancher-turtles.com/
+helm repo add turtles https://rancher.github.io/turtles
 helm repo update
 ```
 and then it can be installed into the `rancher-turtles-system` namespace with:

--- a/versioned_docs/version-0.5/reference-guides/rancher-turtles-chart/values.md
+++ b/versioned_docs/version-0.5/reference-guides/rancher-turtles-chart/values.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 # Chart configuration
 
 :::tip
-For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher-sandbox/rancher-turtles).
+For the up-to-date content of `values.yaml` source file, refer to the [Rancher Turtles repository](https://github.com/rancher/turtles).
 :::
 
 ## Rancher Turtles values

--- a/versioned_docs/version-0.5/tasks/capi-operator/capiprovider_resource.md
+++ b/versioned_docs/version-0.5/tasks/capi-operator/capiprovider_resource.md
@@ -8,7 +8,7 @@ The `CAPIProvider` resource allows managing Cluster API Operator manifests in a 
 
 `CAPIProvider` follows a GitOps model - the spec fields are declarative user inputs. The controller only updates status.
 
-[ARD](https://github.com/rancher-sandbox/rancher-turtles/blob/main/docs/adr/0007-rancher-turtles-public-api.md)
+[ARD](https://github.com/rancher/turtles/blob/main/docs/adr/0007-rancher-turtles-public-api.md)
 
 ## Usage
 
@@ -53,7 +53,7 @@ The key fields in the `CAPIProvider` spec are:
 - `features` - Enabled provider features
 - `variables` - Variables is a map of environment variables to add to the content of the `configSecret`
 
-Full documentation on the CAPIProvider resource - [here](https://doc.crds.dev/github.com/rancher-sandbox/rancher-turtles/turtles-capi.cattle.io/CAPIProvider/v1alpha1@v0.4.0).
+Full documentation on the CAPIProvider resource - [here](https://doc.crds.dev/github.com/rancher/turtles/turtles-capi.cattle.io/CAPIProvider/v1alpha1%2540v0.5.0).
 
 ## Deletion
 


### PR DESCRIPTION
All doc references in previous versions are now pointing to correct helm chart repo and repository location.

Fixes: https://github.com/rancher/turtles-docs/issues/72