### PR TITLE
Always specify foreground deletion on uninstall

### DIFF
--- a/docs/getting-started/install-rancher-turtles/using_rancher_dashboard.md
+++ b/docs/getting-started/install-rancher-turtles/using_rancher_dashboard.md
@@ -29,7 +29,7 @@ If uninstalling, you can refer to [Uninstalling Rancher Turtles](../uninstall_tu
 ### Installation
 
 - From your browser, access Rancher Manager and explore the **local** cluster.
-- Using the left navigation pane, go to `Apps` -> `Repositories`.
+- Using the left navigation panel, go to `Apps` -> `Repositories`.
 - Click `Create` to add a new repository.
 - Enter the following:
     - **Name**: `turtles`.

--- a/docs/getting-started/uninstall_turtles.md
+++ b/docs/getting-started/uninstall_turtles.md
@@ -14,15 +14,10 @@ To simplify uninstalling Rancher Turtles (via Rancher Manager or helm command), 
 - Delete the CAPI `deployments` that are no longer needed.
 :::
 
-There are two options to uninstall the Rancher Turtles depending on the installation method.
-
-1. Rancher Turtles installed via Rancher Manager (i.e in local cluster, `Apps->Repositories` to add a turtles repository then `Apps->Charts` to install rancher-turtles extension). To uninstall, simply navigate to local cluster, `Apps->Installed Apps`, find `rancher-turtles` extension and click `Delete`. 
-
-2. Rancher Turtles installed via [helm command](./install-rancher-turtles/using_helm.md). If you would like to uninstall it manually,
-it can be simply achieived via `helm`:
+To uninstall the Rancher Turtles Extension use the following helm command:
 
 ```bash
-helm uninstall -n rancher-turtles-system rancher-turtles
+helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
 ```
 
 This may take a few minutes to complete.


### PR DESCRIPTION
Turtles extension has to be removed with `foreground` policy to ensure cleanup of CAPI Operator provisioned resources. This has to be reflected in the docs.