### PR TITLE
Move CAPI operator installation notes to Contributing section

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Development setup
@@ -8,9 +8,7 @@ sidebar_position: 2
 
 - [kind](https://kind.sigs.k8s.io/)
 - [helm](https://helm.sh/)
-- [clusterctl](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl)
 - [tilt](https://tilt.dev/)
-
 
 ## Create a local development environment
 
@@ -51,7 +49,10 @@ ngrok http https://localhost:10000
 ## What happens when you run `make dev-env`?
 
 1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher/turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
-1. [Cert manager](https://cert-manager.io/) is installed on the cluster, which is a requirement for running `Rancher turtes` extension.
-1. `clusterctl` is used to bootstrap CAPI components onto the cluster, and a default configuration includes: core Cluster API controller, Kubeadm bootstrap and control plane providers, Docker infrastructure provider.
+1. [Cluster API Operator](../contributing/install_capi_operator.md) is installed using helm, which includes: 
+    - Core Cluster API controller
+    - Kubeadm Bootstrap and Control Plane Providers
+    - Docker Infrastructure Provider
+    - Cert manager
 1. `Rancher manager` is installed using helm.
 1. `tilt up` is run to start the development environment.

--- a/docs/contributing/install_capi_operator.md
+++ b/docs/contributing/install_capi_operator.md
@@ -1,8 +1,12 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # Installing Cluster API Operator
+
+:::caution
+Installing Cluster API Operator by following this page (without it being a Helm dependency to Rancher Turtles) is not a recommended installation method and intended only for local development purposes. 
+:::
 
 This section describes how to install `Cluster API Operator` in the Kubernetes cluster.
 
@@ -69,8 +73,8 @@ helm install ... --set infrastructure="docker:v1.4.6;azure:v1.4.6"
 
 The `infrastructure` flag is set to `docker:v1.4.6;azure:v1.4.6`, representing the desired provider names. This means that the `Cluster API Operator` will install and manage multiple providers, `Docker` and `Azure` respectively, with versions `v1.4.6` specified in this example.
 
-The cluster is now ready to install Rancher Turtles. The default behavior when installing the chart is to install Cluster API Operator as a Helm dependency. Since we decided to install it manually before installing Rancher Turtles, the feature `cluster-api-operator.enabled` must be explicitly disabled as otherwise it would conflict with the existing installation. You can refer to [Install Rancher Turtles without Cluster API Operator](../../getting-started/install-rancher-turtles/using_helm.md#install-rancher-turtles-without-cluster-api-operator-as-a-helm-dependency) to see next steps.
+The cluster is now ready to install Rancher Turtles. The default behavior when installing the chart is to install Cluster API Operator as a Helm dependency. Since we decided to install it manually before installing Rancher Turtles, the feature `cluster-api-operator.enabled` must be explicitly disabled as otherwise it would conflict with the existing installation. You can refer to [Install Rancher Turtles without Cluster API Operator](../getting-started/install-rancher-turtles/using_helm.md#install-rancher-turtles-without-cluster-api-operator-as-a-helm-dependency) to see next steps.
 
 :::tip
-For more fine-grained control of the providers and other components installed with CAPI, see the [Add the infrastructure provider](../../tasks/capi-operator/add_infrastructure_provider.md) section.
+For more fine-grained control of the providers and other components installed with CAPI, see the [Add the infrastructure provider](../tasks/capi-operator/add_infrastructure_provider.md) section.
 :::

--- a/docs/getting-started/install-rancher-turtles/using_helm.md
+++ b/docs/getting-started/install-rancher-turtles/using_helm.md
@@ -90,7 +90,7 @@ For detailed information on the values supported by the chart and their usage, r
 ### Install Rancher Turtles without `Cluster API Operator` as a Helm dependency
 
 :::note
-Remember that if you opt for this installation option, you will need to manage the Cluster API Operator installation yourself. You can follow the [CAPI Operator guide](../../tasks/capi-operator/intro.md)
+Remember that if you opt for this installation option, you will need to manage the Cluster API Operator installation yourself. You can follow the [CAPI Operator guide](../../contributing/install_capi_operator.md)
 :::
 
 The `rancher-turtles` chart is available in https://rancher.github.io/turtles and this Helm repository must be added before proceeding with the installation:

--- a/sidebars.js
+++ b/sidebars.js
@@ -99,7 +99,6 @@ const sidebars = {
           label: 'Cluster API Operator',
           collapsed: true,
           items: [
-            'tasks/capi-operator/intro',
             'tasks/capi-operator/basic_cluster_api_provider_installation',
             'tasks/capi-operator/installing_core_provider',
             'tasks/capi-operator/capiprovider_resource',
@@ -116,6 +115,7 @@ const sidebars = {
       items: [
         'contributing/intro',
         'contributing/guidelines',
+        'contributing/install_capi_operator',
         'contributing/development',
       ],
     },

--- a/versioned_docs/version-0.6/contributing/development.md
+++ b/versioned_docs/version-0.6/contributing/development.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Development setup
@@ -8,9 +8,7 @@ sidebar_position: 2
 
 - [kind](https://kind.sigs.k8s.io/)
 - [helm](https://helm.sh/)
-- [clusterctl](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl)
 - [tilt](https://tilt.dev/)
-
 
 ## Create a local development environment
 
@@ -51,7 +49,10 @@ ngrok http https://localhost:10000
 ## What happens when you run `make dev-env`?
 
 1. A [kind](https://kind.sigs.k8s.io/) cluster is created with the following [configuration](https://github.com/rancher/turtles/blob/main/scripts/kind-cluster-with-extramounts.yaml).
-1. [Cert manager](https://cert-manager.io/) is installed on the cluster, which is a requirement for running `Rancher turtes` extension.
-1. `clusterctl` is used to bootstrap CAPI components onto the cluster, and a default configuration includes: core Cluster API controller, Kubeadm bootstrap and control plane providers, Docker infrastructure provider.
+1. [Cluster API Operator](../contributing/install_capi_operator.md) is installed using helm, which includes: 
+    - Core Cluster API controller
+    - Kubeadm Bootstrap and Control Plane Providers
+    - Docker Infrastructure Provider
+    - Cert manager
 1. `Rancher manager` is installed using helm.
 1. `tilt up` is run to start the development environment.

--- a/versioned_docs/version-0.6/contributing/install_capi_operator.md
+++ b/versioned_docs/version-0.6/contributing/install_capi_operator.md
@@ -1,8 +1,12 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # Installing Cluster API Operator
+
+:::caution
+Installing Cluster API Operator by following this page (without it being a Helm dependency to Rancher Turtles) is not a recommended installation method and intended only for local development purposes.
+:::
 
 This section describes how to install `Cluster API Operator` in the Kubernetes cluster.
 
@@ -69,8 +73,8 @@ helm install ... --set infrastructure="docker:v1.4.6;azure:v1.4.6"
 
 The `infrastructure` flag is set to `docker:v1.4.6;azure:v1.4.6`, representing the desired provider names. This means that the `Cluster API Operator` will install and manage multiple providers, `Docker` and `Azure` respectively, with versions `v1.4.6` specified in this example.
 
-The cluster is now ready to install Rancher Turtles. The default behavior when installing the chart is to install Cluster API Operator as a Helm dependency. Since we decided to install it manually before installing Rancher Turtles, the feature `cluster-api-operator.enabled` must be explicitly disabled as otherwise it would conflict with the existing installation. You can refer to [Install Rancher Turtles without Cluster API Operator](../../getting-started/install-rancher-turtles/using_helm.md#install-rancher-turtles-without-cluster-api-operator-as-a-helm-dependency) to see next steps.
+The cluster is now ready to install Rancher Turtles. The default behavior when installing the chart is to install Cluster API Operator as a Helm dependency. Since we decided to install it manually before installing Rancher Turtles, the feature `cluster-api-operator.enabled` must be explicitly disabled as otherwise it would conflict with the existing installation. You can refer to [Install Rancher Turtles without Cluster API Operator](../getting-started/install-rancher-turtles/using_helm.md#install-rancher-turtles-without-cluster-api-operator-as-a-helm-dependency) to see next steps.
 
 :::tip
-For more fine-grained control of the providers and other components installed with CAPI, see the [Add the infrastructure provider](../../tasks/capi-operator/add_infrastructure_provider.md) section.
+For more fine-grained control of the providers and other components installed with CAPI, see the [Add the infrastructure provider](../tasks/capi-operator/add_infrastructure_provider.md) section.
 :::

--- a/versioned_docs/version-0.6/getting-started/install-rancher-turtles/using_helm.md
+++ b/versioned_docs/version-0.6/getting-started/install-rancher-turtles/using_helm.md
@@ -90,7 +90,7 @@ For detailed information on the values supported by the chart and their usage, r
 ### Install Rancher Turtles without `Cluster API Operator` as a Helm dependency
 
 :::note
-Remember that if you opt for this installation option, you will need to manage the Cluster API Operator installation yourself. You can follow the [CAPI Operator guide](../../tasks/capi-operator/intro.md)
+Remember that if you opt for this installation option, you will need to manage the Cluster API Operator installation yourself. You can follow the [CAPI Operator guide](../../contributing/install_capi_operator.md)
 :::
 
 The `rancher-turtles` chart is available in https://rancher.github.io/turtles and this Helm repository must be added before proceeding with the installation:

--- a/versioned_sidebars/version-0.6-sidebars.json
+++ b/versioned_sidebars/version-0.6-sidebars.json
@@ -85,7 +85,6 @@
           "label": "Cluster API Operator",
           "collapsed": true,
           "items": [
-            "tasks/capi-operator/intro",
             "tasks/capi-operator/basic_cluster_api_provider_installation",
             "tasks/capi-operator/installing_core_provider",
             "tasks/capi-operator/capiprovider_resource",
@@ -102,6 +101,7 @@
       "items": [
         "contributing/intro",
         "contributing/guidelines",
+        "contributing/install_capi_operator",
         "contributing/development"
       ]
     },


### PR DESCRIPTION
Fixes: https://github.com/rancher/turtles/issues/450

Related PR: https://github.com/rancher/turtles/pull/471

Updates main branch and same changes applied to v0.6 version of docs. 