### PR TITLE
docs: add note on installing app into a project

### DIFF
--- a/docs/getting-started/install-rancher-turtles/using_rancher_dashboard.md
+++ b/docs/getting-started/install-rancher-turtles/using_rancher_dashboard.md
@@ -40,6 +40,10 @@ If uninstalling, you can refer to [Uninstalling Rancher Turtles](../uninstall_tu
 - Click `Rancher Turtles - the Cluster API Extension`
 - Click `Install` -> `Next` -> `Install`.
 
+:::caution
+Rancher will select not to install Turtles into a [Project](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/projects-and-namespaces) by default. Installing Turtles into a Project is not supported and the default configuration `None` should be used to avoid unexpected behavior during installation.
+:::
+
 ![install-turtles-from-ui](./install-turtles-from-ui.gif)
 
 This will use the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from Rancher UI or, alternatively, you can opt for the [manual installation via Helm](./using_helm.md). And, if you are interested on learning more about the available values, you can check the [reference guide](../../reference-guides/rancher-turtles-chart/values.md).


### PR DESCRIPTION
### Description

QA reported that Turtles chart will fail to install if selecting installing into Rancher System Project via Rancher Dashboard https://github.com/rancher/turtles/issues/439. After investigation and discussion with the team, we decided that we do not support this for the time being and we add a note to the installation guide in the documentation stating that the default (not into a project) configuration should be used instead.

Fixes #84 