### PR TITLE
docs: add caution admonition with prerequisites

### DIFF
--- a/docs/getting-started/install-rancher-turtles/using_helm.md
+++ b/docs/getting-started/install-rancher-turtles/using_helm.md
@@ -4,6 +4,10 @@ sidebar_position: 4
 
 # Via Helm install
 
+:::caution
+In case you need to review the list of prerequisites (including `cluster-api-operator` and `cert-manager`), you can refer to [this table](../intro.md#prerequisites).
+:::
+
 If you want to manually apply the Helm chart and be in full control of the installation.
 
 This section walks through different installation options for the Rancher Turtles.
@@ -52,8 +56,6 @@ This operation could take a few minutes and, after installing, you can take some
 - `capi-operator`.
 
 :::note
-- If `cert-manager` is already available in the cluster, you can disable its installation as a Rancher Turtles dependency to avoid conflicts:
-`--set cluster-api-operator.cert-manager.enabled=false`
 - For a list of Rancher Turtles versions, refer to [Releases page](https://github.com/rancher/turtles/releases).
 :::
 

--- a/docs/getting-started/install-rancher-turtles/using_rancher_dashboard.md
+++ b/docs/getting-started/install-rancher-turtles/using_rancher_dashboard.md
@@ -9,6 +9,8 @@ This is the recommended option for installing Rancher Turtles.
 Via Rancher UI, and just by adding the Turtles repository, we can easily let Rancher take care of the installation and configuration of the Cluster API Extension.
 
 :::caution
+In case you need to review the list of prerequisites (including `cluster-api-operator` and `cert-manager`), you can refer to [this table](../intro.md#prerequisites).
+
 If you already have Cluster API Operator installed in your cluster, you should use the [manual helm install method](./using_helm.md) instead.
 :::
 


### PR DESCRIPTION
## Description

Users reported that the dependency on `cert-manager` was not visible enough. This PR adds a reminder to check the prerequisites in the installation guide.