### PR TITLE
docs: add caapf to list of experimental providers

### DIFF
--- a/docs/reference-guides/providers.md
+++ b/docs/reference-guides/providers.md
@@ -25,4 +25,5 @@ This is a list of providers that are in an advanced state of development and wil
 
 | Platform        | Code Name                      | Provider Type            | Docs                     |
 |-----------------|--------------------------------|--------------------------|--------------------------|
+| **Fleet Add-on**  | CAAPF                           | Add-on           | https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/tree/main/docs |
 | **vSphere**         | CAPV                           | Infrastructure           | https://github.com/kubernetes-sigs/cluster-api-provider-vsphere |


### PR DESCRIPTION
# Description

There's an ongoing effort to get a first version of the CAAPF docs ready for the next release in which the Add-on provider will be optionally enabled in Turtles https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/51.

This PR adds the provider to the table of providers in experimental state and a link to the markdown docs (this is still broken because at the time of opening this PR the CAAPF one is not yet merged).