### PR TITLE
docs: add capd to list of supported providers

### DIFF
--- a/docs/reference-guides/providers.md
+++ b/docs/reference-guides/providers.md
@@ -18,6 +18,9 @@ This is a list of the officially supported CAPI Providers by Turtles. These prov
 |-----------------|--------------------------------|--------------------------|--------------------------|
 | **RKE2**            | CAPRKE2                    | Bootstrap/Control Plane  | https://github.com/rancher-sandbox/cluster-api-provider-rke2 |
 | **AWS**         | CAPA                           | Infrastructure           | https://cluster-api-aws.sigs.k8s.io |
+| **Docker**\*         | CAPD                           | Infrastructure           | https://cluster-api.sigs.k8s.io |
+
+*Recommended only for development purposes.
 
 ## List of providers in experimental mode
 


### PR DESCRIPTION
# Description

This PR simply adds CAPD to the list of supported providers with a caution note that it is intended only for development purposes (as specified in the official CAPI docs). As most of our examples for getting started with Turtles use CAPD in some way, it may be relevant to list it in the table together with the other production-ready providers.

**Notes**: this change is not urgent and can be added in the next minor release.