### PR TITLE
Fix editUrl

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,7 +66,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/rancher/turtles-docs/tree/main/docs/',
+            'https://github.com/rancher/turtles-docs/tree/main/',
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
The current editUrl leads to a 404 when using the "Edit this page" link on a page from versioned_docs.