### PR TITLE
docs: use capa as capi operator example

### DIFF
--- a/docs/contributing/install_capi_operator.md
+++ b/docs/contributing/install_capi_operator.md
@@ -68,10 +68,10 @@ stringData:
 To select more than one desired provider to be installed together with the `Cluster API Operator`, the `--infrastructure` flag can be specified with multiple provider names separated by a comma. For example:
 
 ```bash
-helm install ... --set infrastructure="docker:v1.4.6;azure:v1.4.6"
+helm install ... --set infrastructure="docker:v1.4.6;aws:v2.3.5"
 ```
 
-The `infrastructure` flag is set to `docker:v1.4.6;azure:v1.4.6`, representing the desired provider names. This means that the `Cluster API Operator` will install and manage multiple providers, `Docker` and `Azure` respectively, with versions `v1.4.6` specified in this example.
+The `infrastructure` flag is set to `docker:v1.4.6;aws:v2.3.5`, representing the desired provider names. This means that the `Cluster API Operator` will install and manage multiple providers, `Docker` and `AWS`, with versions `v1.4.6` and `v2.3.5` respectively.
 
 The cluster is now ready to install Rancher Turtles. The default behavior when installing the chart is to install Cluster API Operator as a Helm dependency. Since we decided to install it manually before installing Rancher Turtles, the feature `cluster-api-operator.enabled` must be explicitly disabled as otherwise it would conflict with the existing installation. You can refer to [Install Rancher Turtles without Cluster API Operator](../getting-started/install-rancher-turtles/using_helm.md#install-rancher-turtles-without-cluster-api-operator-as-a-helm-dependency) to see next steps.
 

--- a/docs/getting-started/intro.md
+++ b/docs/getting-started/intro.md
@@ -35,7 +35,7 @@ This section focuses on implementation details including
 
 ## Tasks
 
-In this section we cover additional [operational tasks](./tasks/intro) including basic `CAPIProvider` [installation](./tasks/capi-operator/basic_cluster_api_provider_installation), an [example](./tasks/capi-operator/add_infrastructure_provider) Azure infrastructure provider install using `CAPIProvider`, and [upgrade instructions](./tasks/early_adopter_upgrade) for early adopters of Rancher Turtles.
+In this section we cover additional [operational tasks](./tasks/intro) including basic `CAPIProvider` [installation](./tasks/capi-operator/basic_cluster_api_provider_installation), an [example](./tasks/capi-operator/add_infrastructure_provider) AWS infrastructure provider install using `CAPIProvider`, and [upgrade instructions](./tasks/early_adopter_upgrade) for early adopters of Rancher Turtles.
 
 ## Security
 

--- a/docs/tasks/capi-operator/add_infrastructure_provider.md
+++ b/docs/tasks/capi-operator/add_infrastructure_provider.md
@@ -2,12 +2,12 @@
 sidebar_position: 3
 ---
 
-# Installing Azure Infrastructure Provider using CAPIProvider resource
+# Installing AWS Infrastructure Provider using CAPIProvider resource
 
-This section describes how to install the Azure `InfrastructureProvider` via `CAPIProvider`, which is responsible for managing Cluster API Azure CRDs and the Cluster API Azure controller.
+This section describes how to install the AWS `InfrastructureProvider` via `CAPIProvider`, which is responsible for managing Cluster API AWS CRDs and the Cluster API AWS controller.
 
 :::note
-This section describes how to install the raw Azure `InfrastructureProvider`, which is responsible for managing the Cluster API Azure CRDs and the Cluster API Azure controller. The detailed configuration steps are described in the [official](https://cluster-api-operator.sigs.k8s.io/03_topics/03_basic-cluster-api-provider-installation/02_installing-capz#installing-azure-infrastructure-provider) CAPI Operator documentation.
+This section describes how to install the raw AWS `InfrastructureProvider`, which is responsible for managing the Cluster API AWS CRDs and the Cluster API AWS controller. The detailed configuration steps are described in the [official](https://cluster-api-operator.sigs.k8s.io/03_topics/03_basic-cluster-api-provider-installation/02_installing-capz#installing-azure-infrastructure-provider) CAPI Operator documentation.
 :::
 
 *Example:*
@@ -17,33 +17,37 @@ This section describes how to install the raw Azure `InfrastructureProvider`, wh
 apiVersion: v1
 kind: Secret
 metadata:
-  name: azure-variables
-  namespace: capz-system
+  name: aws-variables
+  namespace: capa-system
 type: Opaque
 stringData:
-  AZURE_CLIENT_ID_B64: Zm9vCg==
-  AZURE_CLIENT_SECRET_B64: Zm9vCg==
-  AZURE_SUBSCRIPTION_ID_B64: Zm9vCg==
-  AZURE_TENANT_ID_B64: Zm9vCg==
-  github-token: ghp_fff
+  AWS_B64ENCODED_CREDENTIALS: ZZ99ii==
+  ExternalResourceGC: "true"
 ---
 apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
 metadata:
-  name: azure
-  namespace: capz-system
+  name: aws
+  namespace: capa-system
 spec:
-  version: v1.9.3
+  name: aws
   type: infrastructure # required
+  version: v2.3.5
   configSecret:
-    name: azure-variables # This will additionally populate the default set of feature gates for the provider inside the secret
+    name: aws-variables # This will additionally populate the default set of feature gates for the provider inside the secret
+  variables:
+    EXP_MACHINE_POOL: "true"
+    EXP_EXTERNAL_RESOURCE_GC: "true"
+    CAPA_LOGLEVEL: "4"
+  manager:
+    syncPeriod: "5m"
 ```
 
 ### Deleting providers
 
-To remove the installed providers and all related Kubernetes objectsm just delete the following CRs:
+To remove the installed providers and all related Kubernetes objects just delete the following CRs:
 
 ```bash
 kubectl delete coreprovider cluster-api
-kubectl delete infrastructureprovider azure
+kubectl delete infrastructureprovider aws
 ```

--- a/docs/tasks/capi-operator/basic_cluster_api_provider_installation.md
+++ b/docs/tasks/capi-operator/basic_cluster_api_provider_installation.md
@@ -4,4 +4,4 @@ sidebar_position: 1
 
 # Basic Cluster API Provider Installation
 
-This section describes the basic process of installing `CAPI` providers using the operator and a basic configuration of Azure Infrastructure provider. For [section](https://cluster-api-operator.sigs.k8s.io/03_topics/03_basic-cluster-api-provider-installation/#basic-cluster-api-provider-installation) details please refer to official CAPI Operator documentation.
+This section describes the basic process of installing `CAPI` providers using the operator and a basic configuration of AWS Infrastructure provider. For [section](https://cluster-api-operator.sigs.k8s.io/03_topics/03_basic-cluster-api-provider-installation/#basic-cluster-api-provider-installation) details please refer to official CAPI Operator documentation.


### PR DESCRIPTION
# Description

The existing example in Turtles' CAPI Operator docs for installing a `CAPIProvider` refers to upstream's CAPI Operator [book](https://cluster-api-operator.sigs.k8s.io/03_topics/03_basic-cluster-api-provider-installation/02_installing-capz#installing-azure-infrastructure-provider) and Azure Provider. As CAPZ is not yet an officially supported provider in Turtles, we should use a supported provider in the example instead. This changes it from CAPZ to CAPA.