### PR TITLE
docs: switch getting-started examples to caprke2

### DIFF
--- a/docs/getting-started/create-first-cluster/using_fleet.md
+++ b/docs/getting-started/create-first-cluster/using_fleet.md
@@ -9,7 +9,7 @@ This section will guide you through creating your first cluster and importing it
 ## Prerequisites
 
 - Rancher Manager cluster with Rancher Turtles installed
-- Cluster API providers installed for your scenario - we'll be using the Docker infrastructure and Kubeadm bootstrap/control plane providers in these instructions - see [Initialization for common providers](https://cluster-api.sigs.k8s.io/user/quick-start.html#initialization-for-common-providers)
+- Cluster API providers installed for your scenario - we'll be using the [Docker infrastructure](https://github.com/kubernetes-sigs/cluster-api/tree/main/test/infrastructure/docker) and [RKE2 bootstrap/control plane](https://github.com/rancher-sandbox/cluster-api-provider-rke2) providers in these instructions - see [Initialization for common providers using Turtles' `CAPIProvider`](../../tasks/capi-operator/capiprovider_resource.md)
 - **clusterctl** CLI - see the [releases](https://github.com/kubernetes-sigs/cluster-api/releases)
 
 ## Create your cluster definition
@@ -32,7 +32,7 @@ export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.26.4
 
 clusterctl generate cluster cluster1 \
---from https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-kubeadm.yaml \
+--from https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml \
 > cluster1.yaml
 ```
 

--- a/docs/getting-started/create-first-cluster/using_kubectl.md
+++ b/docs/getting-started/create-first-cluster/using_kubectl.md
@@ -9,7 +9,7 @@ This section will guide you through creating your first cluster and importing it
 ## Prerequisites
 
 - Rancher Manager cluster with Rancher Turtles installed
-- Cluster API providers installed for your scenario - we'll be using the Docker infrastructure and Kubeadm bootstrap/control plane providers in these instructions - see [Initialization for common providers](https://cluster-api.sigs.k8s.io/user/quick-start.html#initialization-for-common-providers)
+- Cluster API providers installed for your scenario - we'll be using the [Docker infrastructure](https://github.com/kubernetes-sigs/cluster-api/tree/main/test/infrastructure/docker) and [RKE2 bootstrap/control plane](https://github.com/rancher-sandbox/cluster-api-provider-rke2) providers in these instructions - see [Initialization for common providers using Turtles' `CAPIProvider`](../../tasks/capi-operator/capiprovider_resource.md)
 - **clusterctl** CLI - see the [releases](https://github.com/kubernetes-sigs/cluster-api/releases)
 
 ## Create Your Cluster Definition
@@ -24,7 +24,7 @@ export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.26.4
 
 clusterctl generate cluster cluster1 \
---from https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-kubeadm.yaml \
+--from https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml \
 > cluster1.yaml
 ```
 


### PR DESCRIPTION
# Description

A new CAPD+CAPRKE2 template has been added to the example repository referenced in the getting started guide ([here](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/tree/templates)). This RKE2 base template replaces the old kubeadm-based cluster definition, so users follow the docs with Turtles' default bootstrap/control plane provider.