### PR TITLE
Move CAPI Operator installation docs 

### DIFF
--- a/docs/contributing/install_capi_operator.md
+++ b/docs/contributing/install_capi_operator.md
@@ -78,3 +78,31 @@ The cluster is now ready to install Rancher Turtles. The default behavior when i
 :::tip
 For more fine-grained control of the providers and other components installed with CAPI, see the [Add the infrastructure provider](../tasks/capi-operator/add_infrastructure_provider.md) section.
 :::
+''
+
+### Install Rancher Turtles without `Cluster API Operator` as a Helm dependency
+
+:::note
+This option is only suitable for development purposes and not recommended for production environments.
+:::
+
+The `rancher-turtles` chart is available in https://rancher.github.io/turtles and this Helm repository must be added before proceeding with the installation:
+
+```bash
+helm repo add turtles https://rancher.github.io/turtles
+helm repo update
+```
+
+and then it can be installed into the `rancher-turtles-system` namespace with:
+
+```bash
+helm install rancher-turtles turtles/rancher-turtles --version v0.8.0
+    -n rancher-turtles-system
+    --set cluster-api-operator.enabled=false
+    --set cluster-api-operator.cluster-api.enabled=false
+    --create-namespace --wait
+    --dependency-update
+```
+
+As you can see, we are telling Helm to ignore installing `cluster-api-operator` as a dependency.
+

--- a/docs/getting-started/air-gapped-environment.md
+++ b/docs/getting-started/air-gapped-environment.md
@@ -11,7 +11,7 @@ To provision and configure Cluster API providers, Turtles uses the **CAPIProvide
 To install Cluster API providers in an air-gapped environment the following will need to be done:
 
 1. Configure the Cluster API Operator for an air-gapped environment:
-    - Manually fetch and store a helm chart for the operator.
+    - The operator chart will be fetched and stored as a part of the Turtles chart.
     - Provide image overrides for the operator from an accessible image repository.
 2. Configure Cluster API providers for an air-gapped environment:
     - Provide fetch configuration for each provider from an accessible location (e.g., an internal github/gitlab server) or from pre-created ConfigMaps within the cluster.

--- a/docs/getting-started/install-rancher-turtles/using_helm.md
+++ b/docs/getting-started/install-rancher-turtles/using_helm.md
@@ -5,16 +5,12 @@ sidebar_position: 4
 # Via Helm install
 
 :::caution
-In case you need to review the list of prerequisites (including `cluster-api-operator` and `cert-manager`), you can refer to [this table](../intro.md#prerequisites).
+In case you need to review the list of prerequisites (including `cert-manager`), you can refer to [this table](../intro.md#prerequisites).
 :::
 
 If you want to manually apply the Helm chart and be in full control of the installation.
 
-This section walks through different installation options for the Rancher Turtles.
-- [Install Rancher Turtles with Cluster API Operator as a dependency](#install-rancher-turtles-with-cluster-api-operator-as-a-helm-dependency).
-- [Install Rancher Turtles without Cluster API Operator](#install-rancher-turtles-without-cluster-api-operator-as-a-helm-dependency).
-
-The Cluster API Operator is required for installing Rancher Turtles and you can choose whether you want to take care of this dependency yourself or let the Rancher Turtles Helm chart manage it for you. We recommend [installing as a dependency](#install-rancher-turtles-with-cluster-api-operator-as-a-helm-dependency) for the sake of simplicity, but the best option may depend on your specific configuration.
+The Cluster API Operator is required for installing Rancher Turtles and will be installed as dependency of the Rancher Turtles Helm chart.
 
 CAPI Operator allows handling the lifecycle of Cluster API Providers using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to [Cluster API Operator book](https://cluster-api-operator.sigs.k8s.io/). 
 
@@ -89,31 +85,3 @@ stringData:
 For detailed information on the values supported by the chart and their usage, refer to [Helm chart options](../../reference-guides/rancher-turtles-chart/values)
 :::
 
-### Install Rancher Turtles without `Cluster API Operator` as a Helm dependency
-
-:::note
-Remember that if you opt for this installation option, you will need to manage the Cluster API Operator installation yourself. You can follow the [CAPI Operator guide](../../contributing/install_capi_operator.md)
-:::
-
-The `rancher-turtles` chart is available in https://rancher.github.io/turtles and this Helm repository must be added before proceeding with the installation:
-
-```bash
-helm repo add turtles https://rancher.github.io/turtles
-helm repo update
-```
-
-and then it can be installed into the `rancher-turtles-system` namespace with:
-
-```bash
-helm install rancher-turtles turtles/rancher-turtles --version v0.8.0
-    -n rancher-turtles-system
-    --set cluster-api-operator.enabled=false
-    --set cluster-api-operator.cluster-api.enabled=false
-    --create-namespace --wait
-    --dependency-update
-```
-
-As you can see, we are telling Helm to ignore installing `cluster-api-operator` as a dependency.
-
-This operation could take a few minutes and, after installing, you can take some time to study the installed controller:
-- `rancher-turtles-controller`.

--- a/docs/getting-started/install-rancher-turtles/using_rancher_dashboard.md
+++ b/docs/getting-started/install-rancher-turtles/using_rancher_dashboard.md
@@ -9,9 +9,7 @@ This is the recommended option for installing Rancher Turtles.
 Via Rancher UI, and just by adding the Turtles repository, we can easily let Rancher take care of the installation and configuration of the Cluster API Extension.
 
 :::caution
-In case you need to review the list of prerequisites (including `cluster-api-operator` and `cert-manager`), you can refer to [this table](../intro.md#prerequisites).
-
-If you already have Cluster API Operator installed in your cluster, you should use the [manual helm install method](./using_helm.md) instead.
+In case you need to review the list of prerequisites (including `cert-manager`), you can refer to [this table](../intro.md#prerequisites).
 :::
 
 :::info


### PR DESCRIPTION
Some users confuse the development and production installation of the CAPI operator, for production use cases it has to be installed as a dependency. This PR moves the docs to a place that is better suited for them.