### PR TITLE
docs: add warning after import controller migration

### DIFF
--- a/docs/getting-started/intro.md
+++ b/docs/getting-started/intro.md
@@ -5,6 +5,12 @@ sidebar_position: 1
 
 # Introduction
 
+:::warning
+Starting with Turtles `v0.9.0`, the process used for importing CAPI clusters into Rancher is now based on a different controller logic. If you are a new user of Turtles, you can proceed normally and simply install the extension. If you have been using previous versions of Turtles and are upgrading to `v0.9.0`, we recommend you take a look at the migration mechanisms and their implications:
+- [Automatic migration](../tasks/maintenance/automigrate_to_v3_import.md).
+- [Manual migration](../tasks/maintenance/import_controller_upgrade.md)
+:::
+
 Rancher Turtles is a Kubernetes Operator that provides integration between Rancher Manager and Cluster API (CAPI) with the aim of bringing full CAPI support to Rancher. With Rancher Turtles, you can:
 
 - Automatically import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.

--- a/sidebars.js
+++ b/sidebars.js
@@ -120,7 +120,8 @@ const sidebars = {
           collapsed: true,
           items: [
             'tasks/maintenance/early_adopter_upgrade',
-            'tasks/maintenance/import_controller_upgrade'
+            'tasks/maintenance/import_controller_upgrade',
+            'tasks/maintenance/automigrate_to_v3_import'
           ]
         },
       ]


### PR DESCRIPTION
# Description

Add a warning on `v0.9.0` home page mentioning the import controller migration and recommending existing users to double-check migration mechanisms and implications.