### PR TITLE
docs: reword providers section

### DIFF
--- a/docs/reference-guides/providers/certified.md
+++ b/docs/reference-guides/providers/certified.md
@@ -2,17 +2,17 @@
 sidebar_position: 1
 ---
 
-# Supported CAPI Providers
+# Certified CAPI Providers
 
 Remember that most Cluster API Providers are upstream projects maintained by the Kubernetes open-source community.
 
-## List of officially supported providers
+## List of certified providers
 
 :::note
 This list is constantly evolving to reflect the ongoing development of the project.
 :::
 
-This is a list of the officially supported CAPI Providers by Turtles. These providers are covered by our test suite and we actively ensure that they work properly with the CAPI extension for Rancher.
+This is a list of the officially certified CAPI Providers by Turtles. These providers are covered by our test suite and we actively ensure that they work properly with the CAPI extension for Rancher.
 
 | Platform        | Code Name                      | Provider Type            | Docs                     |
 |-----------------|--------------------------------|--------------------------|--------------------------|
@@ -26,7 +26,7 @@ This is a list of the officially supported CAPI Providers by Turtles. These prov
 
 ## List of providers in experimental mode
 
-This is a list of providers that are in an advanced state of development and will soon become officially supported.
+This is a list of providers that are in an advanced state of development and will soon become certified.
 
 | Platform        | Code Name                      | Provider Type            | Docs                     |
 |-----------------|--------------------------------|--------------------------|--------------------------|

--- a/docs/reference-guides/providers/howto.md
+++ b/docs/reference-guides/providers/howto.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 # Create & import a cluster using CAPI providers
 
-This guide goes over the process of creating and importing CAPI clusters with a selection of the officially supported providers.
+This guide goes over the process of creating and importing CAPI clusters with a selection of the officially certified providers.
 
 Remember that most Cluster API Providers are upstream projects maintained by the Kubernetes open-source community.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -88,7 +88,7 @@ const sidebars = {
           label: 'CAPI Providers',
           collapsed: true,
           items: [
-            'reference-guides/providers/supported',
+            'reference-guides/providers/certified',
             'reference-guides/providers/howto',
             'reference-guides/providers/addon-provider-fleet',
           ]


### PR DESCRIPTION
# Description

After discussions with the team and product, we agreed that we should substitute the term "supported" from the documentation and reflect that the providers are verified/validated instead.

#### Fixes #134 