### PR TITLE
docs: add capa+caprke2 tutorial

### DIFF
--- a/docs/reference-guides/providers/howto.md
+++ b/docs/reference-guides/providers/howto.md
@@ -9,11 +9,18 @@ import TabItem from '@theme/TabItem';
 
 This guide goes over the process of creating and importing CAPI clusters with a selection of the officially supported providers.
 
-Remember that most Cluster API Providers are upstream projects maintained by the Kubernetes open-source community.
+Keep in mind that most Cluster API Providers are upstream projects maintained by the Kubernetes open-source community.
 
 ## Prerequisites
 
 <Tabs>
+  <TabItem value="aws-rke2" label="AWS RKE2" default>
+    - Rancher Manager cluster with Rancher Turtles installed
+    - Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource [here](../../tasks/capi-operator/basic_cluster_api_provider_installation.md)
+        - [Infrastructure provider for AWS](https://github.com/kubernetes-sigs/cluster-api-provider-aws/)
+        - [Bootstrap/Control Plane provider for RKE2](https://github.com/rancher/cluster-api-provider-rke2)
+    - **clusterctl** CLI - see [install clusterctl from CAPI book](https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl)
+    </TabItem>
   <TabItem value="aws-kubeadm" label="AWS Kubeadm" default>
     - Rancher Manager cluster with Rancher Turtles installed
     - Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource [here](../../tasks/capi-operator/basic_cluster_api_provider_installation.md)
@@ -33,6 +40,43 @@ Remember that most Cluster API Providers are upstream projects maintained by the
 ## Create Your Cluster Definition
 
 <Tabs>
+  <TabItem value="aws-rke2" label="AWS RKE2" default>
+
+
+Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the [RKE2 image-builder README](https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws) to build the AMI.
+
+We recommend you refer to the CAPRKE2 repository where you can find a [samples folder](https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws) with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters. The [internal folder](https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/internal) contains cluster templates to deploy an RKE2 cluster on AWS using the internal cloud provider, and the [external folder](https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/external) contains the cluster templates to deploy a cluster with the external cloud provider.
+
+We will use the `internal` one for this guide, however the same steps apply for `external`.
+
+To generate the YAML for the cluster, do the following:
+
+1. Open a terminal and run the following:
+
+```bash
+export CONTROL_PLANE_MACHINE_COUNT=3
+export WORKER_MACHINE_COUNT=3
+export RKE2_VERSION=v1.26.0+rke2r1
+export AWS_NODE_MACHINE_TYPE=t3a.large
+export AWS_CONTROL_PLANE_MACHINE_TYPE=t3a.large
+export AWS_SSH_KEY_NAME="aws-ssh-key"
+export AWS_REGION="aws-region"
+export AWS_AMI_ID="ami-id"
+
+clusterctl generate cluster cluster1 \
+--from https://github.com/rancher/cluster-api-provider-rke2/blob/main/samples/aws/internal/cluster-template.yaml \
+> cluster1.yaml
+```
+2. View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.
+
+> The Cluster API quickstart guide contains more detail. Read the steps related to this section [here](https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers).
+
+3. Create the cluster using kubectl
+
+```bash
+kubectl create -f cluster1.yaml
+```
+    </TabItem>
   <TabItem value="aws-kubeadm" label="AWS Kubeadm" default>
 To generate the YAML for the cluster, do the following:
 
@@ -83,6 +127,15 @@ kubectl create -f cluster1.yaml
 ```
     </TabItem>
 </Tabs>
+
+:::tip
+After your cluster is provisioned, you can check functionality of the workload cluster using `clusterctl`:
+```bash
+clusterctl describe cluster cluster1
+```
+
+Remember that clusters are namespaced resources. These examples provision clusters in the `default` namespace, but you will need to provide yours if using a different one.
+:::
 
 ## Mark Namespace or Cluster for Auto-Import
 


### PR DESCRIPTION
# Description

Add tutorial on how to create AWS clusters with RKE2 provider.

Fixes #117 