### PR TITLE
Add CAAPF documentation page

### DIFF
--- a/docs/reference-guides/providers/addon-provider-fleet.md
+++ b/docs/reference-guides/providers/addon-provider-fleet.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 2
+---
+
+# Cluster API Addon Provider Fleet
+
+## Owerview
+
+Cluster API Add-on Provider for `Fleet` (CAAPF) is a Cluster API (CAPI) provider that provides integration with [`Fleet`](https://fleet.rancher.io/) to enable the easy deployment of applications to a CAPI provisioned cluster.
+
+## Functionality
+
+- The provider will register a newly provisioned CAPI cluster with `Fleet` by creating a `Fleet` `Cluster` instance with the same `name` and `namespace`. Applications can be automatically deployed to the created cluster using `GitOps`.
+- The provider will automatically create a Fleet `ClusterGroup` for every CAPI `ClusterClass` in the `ClusterClass` namespace. This enables you to deploy the same applications to all clusters created from the same `ClusterClass`.
+
+This allows a user to specify either a [`Bundle`](https://fleet.rancher.io/ref-bundle) resource with raw application workloads, or [`GitRepo`](https://fleet.rancher.io/ref-gitrepo) to install applications from git. Each of the resources can provide [`targets`](https://fleet.rancher.io/gitrepo-targets#defining-targets) with any combination of:
+
+```yaml
+  targets:
+  - clusterGroup: <cluster-class-name> # If the cluster is created from cluster-class
+  - clusterName: <a specific CAPI cluster name>
+```
+
+Additionally, `CAAPF` automatically propagates `CAPI` cluster labels to the `Fleet` cluster resource, so user can specify a target matching common cluster label with:
+
+```yaml
+  targets:
+  - clusterSelector: <label selector for the cluster instances, inherited from CAPI clusters>
+  - clusterGroupSelector: <label selector for the cluster group instances, labels inherited from ClusterClass>
+```
+
+## Example - deploying kindnet CNI
+
+:::warning
+The following example requires `Fleet` version `>=v0.10.1-rc.1`, which is not a part of `rancher/charts` yet.
+:::
+
+**Demo**: [![asciicast](https://asciinema.org/a/seEFHKz5DVpUe5CQvWcddSJBp.svg)](https://asciinema.org/a/seEFHKz5DVpUe5CQvWcddSJBp)

--- a/docs/reference-guides/providers/supported.md
+++ b/docs/reference-guides/providers/supported.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 ---
 
 # Supported CAPI Providers
@@ -20,6 +20,7 @@ This is a list of the officially supported CAPI Providers by Turtles. These prov
 | **Kubeadm**     | Kubeadm                    | Bootstrap/Control Plane  | https://github.com/kubernetes-sigs/cluster-api |
 | **AWS**         | CAPA                           | Infrastructure           | https://cluster-api-aws.sigs.k8s.io |
 | **Docker**\*    | CAPD                           | Infrastructure           | https://cluster-api.sigs.k8s.io |
+| **Addon Provider Fleet**    | CAAPF                           | Addon           | http://github.com/rancher-sandbox/cluster-api-addon-provider-fleet |
 
 *Recommended only for development purposes.
 
@@ -29,5 +30,4 @@ This is a list of providers that are in an advanced state of development and wil
 
 | Platform        | Code Name                      | Provider Type            | Docs                     |
 |-----------------|--------------------------------|--------------------------|--------------------------|
-| **Fleet Add-on**  | CAAPF                           | Add-on           | https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/tree/main/docs |
 | **vSphere**         | CAPV                           | Infrastructure           | https://github.com/kubernetes-sigs/cluster-api-provider-vsphere |

--- a/sidebars.js
+++ b/sidebars.js
@@ -90,6 +90,7 @@ const sidebars = {
           items: [
             'reference-guides/providers/supported',
             'reference-guides/providers/howto',
+            'reference-guides/providers/addon-provider-fleet',
           ]
         },
       ],


### PR DESCRIPTION
Add a short overview of functionality for the addon provider Fleet and a demo.

Fixes: https://github.com/rancher/turtles/issues/616