### PR TITLE
add label on new version pr

### DIFF
--- a/.github/workflows/version-publish.yaml
+++ b/.github/workflows/version-publish.yaml
@@ -40,4 +40,4 @@ jobs:
           [[ $tag =~ [0-9]+\.[0-9]+\.[0-9]+ ]] || tag+=.0
           echo -e "Update docs version v${tag}\\n\\nChangelog: https://github.com/rancher/turtles/releases/tag/v${tag}\\n\\ncc @rancher/highlander" > body
           export body=$(cat body)
-          gh pr create --title 'turtles-docs release for turtles v${{ env.TAG }}' --body "$body"
+          gh pr create --title 'turtles-docs release for turtles v${{ env.TAG }}' --body "$body" --label "area/documentation"


### PR DESCRIPTION
# Description

After cutting a new release, `version-publish` workflow automatically creates a PR to publish a new version of the documentation but CI checks won't execute unless a label is assigned on the PR. Hopefully adding the `area/documentation` label at PR creation will have the same effect and we don't have to manually apply changes.