### PR TITLE
Removed sub-module reference

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      with:
-          submodules: recursive
     - name: Configure Pages
       uses: actions/configure-pages@v3
     - name: Install Node.js


### PR DESCRIPTION
Git sub-module was referenced, as this action is based from the Prime docs which uses it. Removed the reference.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>