### PR TITLE
Update playbook-remote.yml

### DIFF
--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -1,11 +1,11 @@
 site:
-  title: Cluster-API
+  title: Rancher Turtles
   url: /
-  start_page: v0.13@cluster-api:en:index.adoc
+  start_page: v0.13@turtles:en:index.adoc
 
 content:
   sources:
-    - url: https://github.com/rancher/turtles-product-docs.git
+    - url: https://github.com/rancher/turtles-docs.git
       branches: [main]
       start_paths: [versions/v0.13, versions/v0.12, versions/v0.11]
 
@@ -14,7 +14,7 @@ ui:
   bundle:
     url: https://github.com/rancher/product-docs-ui/blob/main/build/ui-bundle.zip?raw=true
     snapshot: true
-  supplemental_files: ./product-docs-supplemental-files
+  supplemental_files: ./turtles-supplemental-files
 
 runtime:
   fetch: true


### PR DESCRIPTION
The remote playbook was still referencing the product docs. Updated it to use the project repo.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>