### PR TITLE
Swap remote for local playbook

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Antora with the Antora Lunr Extension
       run: make environment
     - name: Generate Site
-      run: make remote
+      run: make local
     - name: Upload Artifacts
       uses: actions/upload-pages-artifact@v2
       with:


### PR DESCRIPTION
Swapped the build phase to use the local playbook. This is a main difference from the Product docs as the site is built from the same repo, instead of a remote one.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>