### PR TITLE
Automatically generate release notes with releasepost

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,35 @@
+---
+name: "Updatecli daily"
+
+on:
+  # run daily or manually
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 * * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Install updatecli"
+        uses: "updatecli/updatecli-action@v2.75.0"
+        with:
+          version: "v0.92.0"
+        
+      - name: "Install Releasepost"
+        uses: "updatecli/releasepost-action@v0.4.0"
+
+      - name: Run Updatecli in enforce mode
+        run: "updatecli compose apply --file updatecli-compose.yaml"
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releasepost.yaml
+++ b/.releasepost.yaml
@@ -1,0 +1,19 @@
+changelogs:
+  - kind: github
+    dir: docs/next/modules/en/pages/changelogs
+    formats:
+      - extension: asciidoc
+        frontmatters: |
+          == "{{ .Changelog.Name }}"
+          === "{{ .Changelog.PublishedAt }}"
+        indexfilename: index
+        indexfrontmatters: |
+          = Release Notes
+        indexfiletemplate: |
+          {{ .FrontMatters }}
+          {{ range $pos, $release := .Changelogs }}
+          * link:changelogs/{{ $release.Tag }}.html[{{ $release.Name }} {{ if (eq $pos 0) }}(latest){{ end}}]
+          {{ end }}
+    spec:
+      owner: rancher
+      repository: turtles

--- a/docs/next/modules/en/nav.adoc
+++ b/docs/next/modules/en/nav.adoc
@@ -51,3 +51,4 @@
 ** xref:reference/glossary.adoc[Glossary]
 * Security
 ** xref:security/slsa.adoc[SLSA]
+* xref:changelogs/index.adoc[Release Notes]

--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -1,0 +1,13 @@
+policies:
+  # The following policies are designed to work from GitHub action workflows.
+  # This means that before running any Updatecli command, we need the two following environment variables set:
+  # 
+  #   GITHUB_TOKEN: Set to a personal access token
+  #   GITHUB_ACTOR: Set to the username associated with the GITHUB_TOKEN
+  # 
+  # Instruction to retrieve your PAT is documented on https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+  - name: Handle releasepost
+    policy: ghcr.io/salasberryfin/rancherlabs-policies/releasepost:0.1.0@sha256:4f34a64936426fdfe723e9380ddaa866453eddec893e82151caf3fe46a008fb6
+    values:
+      - updatecli/values.d/scm.yaml
+      - updatecli/values.d/turtles.yaml

--- a/updatecli/values.d/scm.yaml
+++ b/updatecli/values.d/scm.yaml
@@ -1,0 +1,9 @@
+# Settings used by releasepost Updatecli policy
+# to identify which Git repository to update.
+scm:
+  enabled: true
+  user: "updatecli-bot"
+  email: "bot@rancher.io"
+  owner: rancher
+  repository: turtles-docs
+  branch: main

--- a/updatecli/values.d/turtles.yaml
+++ b/updatecli/values.d/turtles.yaml
@@ -1,0 +1,4 @@
+# Settings used by releasepost Updatecli policy
+# to identify which GitHub repository to monitor for information releases and changelog information
+project: "Turtles"
+repository: "rancher/turtles"


### PR DESCRIPTION
# Description

This PR adds the tool `releasepost`, which integrates with `updatecli`, to automatically retrieve release notes from Turtles' releases and publish them to a new `Release Notes` section in the documentation site.

For each release, there would be a new line added to the general `Release Notes` site with a link to the specific changelog. All of these changes are published to the `next` version, so docs should be release after `updatecli`'s PR is merged.

## Context

This is similar to the approach used in Fleet. You can use the following configuration files as reference:
- [releasepost.yaml](https://github.com/rancher/fleet-docs/blob/main/releasepost.yaml)
- [updatecli-compose.yaml](https://github.com/rancher/fleet-docs/blob/main/update-compose.yaml)
- [GitHub Actions workflow[(https://github.com/rancher/fleet-docs/blob/main/.github/workflows/updatecli.yml)

The workflow uses a policy (the logic for the automation) that is hosted in an OCI registry: https://github.com/users/salasberryfin/packages/container/rancherlabs-policies%2Freleasepost/settings. This may better be stored in a Rancher-specific repository but for now I think this is okay, as Fleet's configuration is similar.

## Notes

**The following is a sample PR with all release notes up until now (as none are published, updatecli should be clever enough to only commit new changes):** https://github.com/salasberryfin/rancher-turtles-docs/pull/8