### PR TITLE
Clarify recommended way of disabling Rancher features

### DIFF
--- a/docs/next/modules/en/pages/getting-started/install-rancher-turtles/using_helm.adoc
+++ b/docs/next/modules/en/pages/getting-started/install-rancher-turtles/using_helm.adoc
@@ -12,11 +12,11 @@ The Cluster API Operator is required for installing {product_name} and will be i
 
 CAPI Operator allows handling the lifecycle of Cluster API Providers using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to https://cluster-api-operator.sigs.k8s.io/[Cluster API Operator book].
 
-[IMPORTANT]
+[CAUTION]
 ====
-Before <<_install_rancher_turtles_with_cluster_api_operator_as_a_helm_dependency,installing {product_name}>> in your Rancher environment, Rancher's `embedded-cluster-api` functionality must be disabled. This includes also cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
+Rancher's `embedded-cluster-api` functionality will be disabled when installing {product_name}. This includes also cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
 
-To simplify setting up Rancher for installing {product_name}, the official {product_name} Helm chart includes a `pre-install` hook that applies these changes, making it transparent to the end user:
+The recommended way to disable this feature and the Rancher-specific webhooks, is to use the official {product_name} Helm chart, that includes a `pre-install` hook to apply the following changes:  
 
 * Disable the `embedded-cluster-api` feature in Rancher.
 * Delete the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks that are no longer needed.

--- a/docs/next/modules/en/pages/getting-started/install-rancher-turtles/using_rancher_dashboard.adoc
+++ b/docs/next/modules/en/pages/getting-started/install-rancher-turtles/using_rancher_dashboard.adoc
@@ -11,11 +11,11 @@ In case you need to review the list of prerequisites (including `cert-manager`),
 ====
 
 
-[IMPORTANT]
+[CAUTION]
 ====
-Before xref:./using_helm.adoc#_install_rancher_turtles_with_cluster_api_operator_as_a_helm_dependency[installing {product_name}] in your Rancher environment, Rancher's `embedded-cluster-api` functionality must be disabled. This includes also cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
+Rancher's `embedded-cluster-api` functionality will be disabled when installing {product_name}. This includes also cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
 
-To simplify setting up Rancher for installing {product_name}, the official {product_name} Helm chart includes a `pre-install` hook that applies these changes, making it transparent to the end user:
+The recommended way to disable this feature and the Rancher-specific webhooks, is to use the official {product_name} Helm chart, that includes a `pre-install` hook to apply the following changes:  
 
 * Disable the `embedded-cluster-api` feature in Rancher.
 * Delete the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks that are no longer needed.

--- a/docs/v0.15/modules/en/pages/getting-started/install-rancher-turtles/using_helm.adoc
+++ b/docs/v0.15/modules/en/pages/getting-started/install-rancher-turtles/using_helm.adoc
@@ -12,11 +12,11 @@ The Cluster API Operator is required for installing {product_name} and will be i
 
 CAPI Operator allows handling the lifecycle of Cluster API Providers using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to https://cluster-api-operator.sigs.k8s.io/[Cluster API Operator book].
 
-[IMPORTANT]
+[CAUTION]
 ====
-Before <<_install_rancher_turtles_with_cluster_api_operator_as_a_helm_dependency,installing {product_name}>> in your Rancher environment, Rancher's `embedded-cluster-api` functionality must be disabled. This includes also cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
+Rancher's `embedded-cluster-api` functionality will be disabled when installing {product_name}. This includes also cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
 
-To simplify setting up Rancher for installing {product_name}, the official {product_name} Helm chart includes a `pre-install` hook that applies these changes, making it transparent to the end user:
+The recommended way to disable this feature and the Rancher-specific webhooks, is to use the official {product_name} Helm chart, that includes a `pre-install` hook to apply the following changes:  
 
 * Disable the `embedded-cluster-api` feature in Rancher.
 * Delete the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks that are no longer needed.

--- a/docs/v0.15/modules/en/pages/getting-started/install-rancher-turtles/using_rancher_dashboard.adoc
+++ b/docs/v0.15/modules/en/pages/getting-started/install-rancher-turtles/using_rancher_dashboard.adoc
@@ -11,16 +11,15 @@ In case you need to review the list of prerequisites (including `cert-manager`),
 ====
 
 
-[IMPORTANT]
+[CAUTION]
 ====
-Before xref:./using_helm.adoc#_install_rancher_turtles_with_cluster_api_operator_as_a_helm_dependency[installing {product_name}] in your Rancher environment, Rancher's `embedded-cluster-api` functionality must be disabled. This includes also cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
+Rancher's `embedded-cluster-api` functionality will be disabled when installing {product_name}. This includes also cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
 
-To simplify setting up Rancher for installing {product_name}, the official {product_name} Helm chart includes a `pre-install` hook that applies these changes, making it transparent to the end user:
+The recommended way to disable this feature and the Rancher-specific webhooks, is to use the official {product_name} Helm chart, that includes a `pre-install` hook to apply the following changes:  
 
 * Disable the `embedded-cluster-api` feature in Rancher.
 * Delete the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks that are no longer needed.
 ====
-
 
 If you would like to understand how {product_name} works and what the architecture looks like, you can refer to the xref:../../reference-guides/architecture/intro.adoc[Architecture] section.
 


### PR DESCRIPTION
I slightly changed the wording to clarify the Turtles chart is taking care of Rancher settings, **and** this is the recommended way of handling it (since otherwise it will fail).

 I also think this is no longer "important", since it's fully automated by the chart, but still something to be "cautious" about, since it impacts existing Rancher instances.