### PR TITLE
fix: add empty changelogs index file

### DIFF
--- a/docs/next/modules/en/nav.adoc
+++ b/docs/next/modules/en/nav.adoc
@@ -52,4 +52,4 @@
 ** xref:reference/features.adoc[Features]
 * Security
 ** xref:security/slsa.adoc[SLSA]
-// * xref:changelogs/index.adoc[Release Notes]
+* xref:changelogs/index.adoc[Release Notes]


### PR DESCRIPTION
# Description

Add missing `index` file for newly added automatic release notes publishing. Generating the documentation failed because there was a reference to a non-existent file.