### PR TITLE
docs: Add instructions on installing CAPRKE2 when CAPI operator is disabled in Turtles chart

### DIFF
--- a/docs/next/modules/en/pages/developer-guide/install_capi_operator.adoc
+++ b/docs/next/modules/en/pages/developer-guide/install_capi_operator.adoc
@@ -15,7 +15,7 @@ This section describes how to install `Cluster API Operator` in the Kubernetes c
 
 === Install manually with Helm (alternative)
 
-To install `Cluster API Operator` with version `1.7.3` of the `CAPI` + `Docker` provider using helm, follow these steps:
+To install `Cluster API Operator` with version `1.9.3` of the `CAPI` + `Docker` provider using helm, follow these steps:
 
 . Add the Helm repository for the `Cluster API Operator`:
 +
@@ -45,8 +45,8 @@ helm install cert-manager jetstack/cert-manager --namespace cert-manager --creat
 ----
 helm install capi-operator capi-operator/cluster-api-operator \
  --create-namespace -n capi-operator-system \
- --set infrastructure=docker:v1.7.7 \
- --set core=cluster-api:v1.7.7 \
+ --set infrastructure=docker:v1.9.3 \
+ --set core=cluster-api:v1.9.3 \
  --timeout 90s --wait # Core Cluster API with kubeadm bootstrap and control plane providers will also be installed
 ----
 
@@ -62,8 +62,8 @@ To provide additional environment variables, enable feature gates, or supply clo
 ----
 helm install capi-operator capi-operator/cluster-api-operator \
 	--create-namespace -n capi-operator-system \
-	--set infrastructure=docker:v1.7.7 \
-	--set core=cluster-api:v1.7.7 \
+	--set infrastructure=docker:v1.9.3 \
+	--set core=cluster-api:v1.9.3 \
 	--timeout 90s \
 	--secret-name <secret_name> \
 	--wait
@@ -88,10 +88,10 @@ To select more than one desired provider to be installed together with the `Clus
 
 [source,bash]
 ----
-helm install ... --set infrastructure="docker:v1.7.7;aws:v2.6.1"
+helm install ... --set infrastructure="docker:v1.9.3;aws:v2.7.1"
 ----
 
-The `infrastructure` flag is set to `docker:v1.7.7;aws:v2.6.1`, representing the desired provider names. This means that the `Cluster API Operator` will install and manage multiple providers, `Docker` and `AWS`, with versions `v1.7.7` and `v2.6.1` respectively.
+The `infrastructure` flag is set to `docker:v1.9.3;aws:v2.7.1`, representing the desired provider names. This means that the `Cluster API Operator` will install and manage multiple providers, `Docker` and `AWS`, with versions `v1.9.3` and `v2.7.1` respectively.
 
 The cluster is now ready to install {product_name}. The default behavior when installing the chart is to install Cluster API Operator as a Helm dependency. Since we decided to install it manually before installing {product_name}, the feature `cluster-api-operator.enabled` must be explicitly disabled as otherwise it would conflict with the existing installation. You can refer to xref:../developer-guide/install_capi_operator.adoc#_install_suse_rancher_prime_cluster_api_without_cluster_api_operator_as_a_helm_dependency[Install {product_name} without Cluster API Operator] to see next steps.
 
@@ -181,7 +181,7 @@ metadata:
 spec:
   name: cluster-api
   type: core
-  version: v1.7.7
+  version: v1.9.3
   additionalManifests:
     name: capi-additional-rbac-roles
     namespace: capi-system

--- a/docs/next/modules/en/pages/developer-guide/install_capi_operator.adoc
+++ b/docs/next/modules/en/pages/developer-guide/install_capi_operator.adoc
@@ -43,10 +43,10 @@ helm install cert-manager jetstack/cert-manager --namespace cert-manager --creat
 +
 [source,bash]
 ----
-helm install capi-operator capi-operator/cluster-api-operator
- --create-namespace -n capi-operator-system
- --set infrastructure=docker:v1.7.7
- --set core=cluster-api:v1.7.7
+helm install capi-operator capi-operator/cluster-api-operator \
+ --create-namespace -n capi-operator-system \
+ --set infrastructure=docker:v1.7.7 \
+ --set core=cluster-api:v1.7.7 \
  --timeout 90s --wait # Core Cluster API with kubeadm bootstrap and control plane providers will also be installed
 ----
 
@@ -60,12 +60,12 @@ To provide additional environment variables, enable feature gates, or supply clo
 
 [source,bash]
 ----
-helm install capi-operator capi-operator/cluster-api-operator
-	--create-namespace -n capi-operator-system
-	--set infrastructure=docker:v1.7.7
-	--set core=cluster-api:v1.7.7
-	--timeout 90s
-	--secret-name <secret_name>
+helm install capi-operator capi-operator/cluster-api-operator \
+	--create-namespace -n capi-operator-system \
+	--set infrastructure=docker:v1.7.7 \
+	--set core=cluster-api:v1.7.7 \
+	--timeout 90s \
+	--secret-name <secret_name> \
 	--wait
 ----
 
@@ -120,12 +120,98 @@ and then it can be installed into the `rancher-turtles-system` namespace with:
 
 [source,bash]
 ----
-helm install rancher-turtles turtles/rancher-turtles --version v0.13.0
-    -n rancher-turtles-system
-    --set cluster-api-operator.enabled=false
-    --set cluster-api-operator.cluster-api.enabled=false
-    --create-namespace --wait
+helm install rancher-turtles turtles/rancher-turtles --version v0.15.0 \
+    -n rancher-turtles-system \
+    --set cluster-api-operator.enabled=false \
+    --set cluster-api-operator.cluster-api.enabled=false \
+    --create-namespace --wait \
     --dependency-update
 ----
 
 As you can see, we are telling Helm to ignore installing `cluster-api-operator` as a dependency.
+
+In this case, you must apply the following recource configs to the cluster, in order to be able to use CAPRKE2:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rke2-bootstrap-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rke2-control-plane-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: capi-additional-rbac-roles
+  namespace: capi-system
+data: 
+  manifests: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: provisioning-rke-cattle-io
+      labels:
+        cluster.x-k8s.io/aggregate-to-manager: "true"
+    rules:
+      - apiGroups: ["rke.cattle.io"]
+        resources: ["*"]
+        verbs: ["*"]
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: provisioning-rke-machine-cattle-io
+      labels:
+        cluster.x-k8s.io/aggregate-to-manager: "true"
+    rules:
+      - apiGroups: ["rke-machine.cattle.io"]
+        resources: ["*"]
+        verbs: ["*"]
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: cluster-api
+  namespace: capi-system
+spec:
+  name: cluster-api
+  type: core
+  version: v1.7.7
+  additionalManifests:
+    name: capi-additional-rbac-roles
+    namespace: capi-system
+  configSecret:
+    name: capi-env-variables
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: rke2-bootstrap
+  namespace: rke2-bootstrap-system
+spec:
+  name: rke2
+  type: bootstrap
+  configSecret:
+    name: capi-env-variables
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: rke2-control-plane
+  namespace: rke2-control-plane-system
+spec:
+  name: rke2
+  type: controlPlane
+  configSecret:
+    name: capi-env-variables
+----
+
+[NOTE]
+====
+In the resource manifests above, ensure that the version set for the core CAPI Provider is the same version of CAPI that is supported by Rancher Turtles.
+====


### PR DESCRIPTION
When installing CAPI operator in stand-alone mode (i.e. not through the Turtles chart) there are some extra resource manifests that need to be applied.

Note that the only other notable difference when installing Turtles with CAPI operator vs when installing Turtles without CAPI operator is that in the latter case, the CAPI operator deployment is missing a [readonly mount for clusterctl-config](https://github.com/rancher/turtles/blob/main/charts/rancher-turtles/values.yaml#L51-L53). Not sure if we need to include this in the instructions as well, please advice.

Closes: #111 