### PR TITLE
chore: bump updatecli policy for release notes

### DIFF
--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -7,7 +7,7 @@ policies:
   # 
   # Instruction to retrieve your PAT is documented on https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
   - name: Handle releasepost
-    policy: ghcr.io/salasberryfin/rancherlabs-policies/releasepost:0.1.0@sha256:4f34a64936426fdfe723e9380ddaa866453eddec893e82151caf3fe46a008fb6
+    policy: ghcr.io/salasberryfin/rancherlabs-policies/releasepost:0.2.0@sha256:2ab7a5edc38a30672184feffbea19805513ffe1c4e174bf3430cbdfdf4698f0f 
     values:
       - updatecli/values.d/scm.yaml
       - updatecli/values.d/turtles.yaml


### PR DESCRIPTION
# Description

Since moving to Antora, this repository [contains sub-modules](https://github.com/rancher/turtles-docs/blob/main/.gitmodules) which is causing errors when updatecli tries to clone it for the release notes automation. The policy used to control these bumps has been updated to disable sub-modules and avoid this error and this PR simply changes the version of the policy used to point to the latest iteration.