### PR TITLE
🐛 Allow setting custom namespace and fix envsubst command

### DIFF
--- a/docs/next/modules/en/pages/getting-started/create-first-cluster/using_fleet.adoc
+++ b/docs/next/modules/en/pages/getting-started/create-first-cluster/using_fleet.adoc
@@ -36,7 +36,9 @@ export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.30.0
 
-curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml | envsubst > cluster1.yaml
+# use the SHELL-FORMAT in envsubst to ensure we replace only the
+# environment variables we exported above
+curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml | envsubst '$CLUSTER_NAME,$CONTROL_PLANE_MACHINE_COUNT,$WORKER_MACHINE_COUNT,$KUBERNETES_VERSION' > cluster1.yaml
 ----
 +
 . View *cluster1.yaml* to ensure there are no tokens. You can make any changes you want as well.

--- a/docs/next/modules/en/pages/getting-started/create-first-cluster/using_fleet.adoc
+++ b/docs/next/modules/en/pages/getting-started/create-first-cluster/using_fleet.adoc
@@ -35,10 +35,11 @@ export CLUSTER_NAME=cluster1
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.30.0
+export NAMESPACE=default
 
 # use the SHELL-FORMAT in envsubst to ensure we replace only the
 # environment variables we exported above
-curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml | envsubst '$CLUSTER_NAME,$CONTROL_PLANE_MACHINE_COUNT,$WORKER_MACHINE_COUNT,$KUBERNETES_VERSION' > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml | envsubst '$CLUSTER_NAME,$CONTROL_PLANE_MACHINE_COUNT,$WORKER_MACHINE_COUNT,$KUBERNETES_VERSION,$NAMESPACE' > cluster1.yaml
 ----
 +
 . View *cluster1.yaml* to ensure there are no tokens. You can make any changes you want as well.

--- a/docs/next/modules/en/pages/tasks/capi-operator/capiprovider_resource.adoc
+++ b/docs/next/modules/en/pages/tasks/capi-operator/capiprovider_resource.adoc
@@ -7,7 +7,7 @@ The `CAPIProvider` resource allows managing Cluster API Operator manifests in a 
 
 Every field provided by the upstream CAPI Operator resource for the desired `spec.type` is also available in the spec of the `CAPIProvider` resouce. Feel free to refer to upstream configuration https://cluster-api-operator.sigs.k8s.io/03_topics/02_configuration/[guides] for advanced scenarios.
 
-https://github.com/rancher/turtles/blob/main/docs/adr/0007-rancher-turtles-public-api.md[ARD]
+https://github.com/rancher/turtles/blob/main/docs/adr/0007-rancher-turtles-public-api.md[ADR]
 
 == Usage
 


### PR DESCRIPTION
* Allow user to set custom namespace to deploy CAPI cluster to.
* `envsubst` command replaces everything with `$` in the file. This causes `$server` and `$address` to be replaced with empty strings in the resulting `cluster1.yaml` file. Using SHELL-FORMAT ensures `envsubst` replaces only the env vars it's being asked to replace.