### PR TITLE
Do not use default namespace

### DIFF
--- a/docs/next/modules/en/pages/developer-guide/install_capi_operator.adoc
+++ b/docs/next/modules/en/pages/developer-guide/install_capi_operator.adoc
@@ -77,7 +77,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: variables
-  namespace: default
+  namespace: capi-operator-system
 type: Opaque
 stringData:
   CLUSTER_TOPOLOGY: "true"

--- a/docs/next/modules/en/pages/getting-started/create-first-cluster/using_fleet.adoc
+++ b/docs/next/modules/en/pages/getting-started/create-first-cluster/using_fleet.adoc
@@ -35,7 +35,7 @@ export CLUSTER_NAME=cluster1
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.30.0
-export NAMESPACE=default
+export NAMESPACE=capi-clusters
 
 # use the SHELL-FORMAT in envsubst to ensure we replace only the
 # environment variables we exported above
@@ -59,14 +59,14 @@ The Cluster API quickstart guide contains more detail. Read the steps related to
 +
 [source,yaml]
 ----
-namespace: default
+namespace: capi-clusters
 ----
 +
 . Commit the changes
 
 [NOTE]
 ====
-The *fleet.yaml* is used to specify configuration options for fleet (see https://fleet.rancher.io/ref-fleet-yaml[docs] for further details). In this instance its declaring that the cluster definitions should be added to the *default* namespace
+The *fleet.yaml* is used to specify configuration options for fleet (see https://fleet.rancher.io/ref-fleet-yaml[docs] for further details). In this instance its declaring that the cluster definitions should be added to the *capi-clusters* namespace
 ====
 
 
@@ -84,11 +84,11 @@ In both cases the label is `cluster-api.cattle.io/rancher-auto-import`.
 This walkthrough will use the first option of importing all clusters in a namespace.
 
 . Open a terminal
-. Label the default namespace in your Rancher Manager cluster:
+. Label the capi-clusters namespace in your Rancher Manager cluster:
 +
 [source,bash]
 ----
-kubectl label namespace default cluster-api.cattle.io/rancher-auto-import=true
+kubectl label namespace capi-clusters cluster-api.cattle.io/rancher-auto-import=true
 ----
 
 == Configure Rancher Manager

--- a/docs/next/modules/en/pages/getting-started/create-first-cluster/using_kubectl.adoc
+++ b/docs/next/modules/en/pages/getting-started/create-first-cluster/using_kubectl.adoc
@@ -21,6 +21,7 @@ export CLUSTER_NAME=cluster1
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.30.0
+export NAMESPACE=capi-clusters
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml | envsubst > cluster1.yaml
 ----
@@ -49,7 +50,7 @@ Labeling a namespace:
 
 [source,bash]
 ----
-kubectl label namespace default cluster-api.cattle.io/rancher-auto-import=true
+kubectl label namespace capi-clusters cluster-api.cattle.io/rancher-auto-import=true
 ----
 
 Labeling an individual cluster definition:

--- a/docs/next/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/docs/next/modules/en/pages/reference-guides/providers/howto.adoc
@@ -114,6 +114,7 @@ export CLUSTER_NAME=cluster1
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.30.0
+export NAMESPACE=capi-clusters
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
 ----
@@ -140,7 +141,7 @@ After your cluster is provisioned, you can check functionality of the workload c
 kubectl describe cluster cluster1
 ----
 
-Remember that clusters are namespaced resources. These examples provision clusters in the `default` namespace, but you will need to provide yours if using a different one.
+Remember that clusters are namespaced resources. These examples provision clusters in the `capi-clusters` namespace, but you will need to provide yours if using a different one.
 ====
 
 
@@ -155,7 +156,7 @@ Labeling a namespace:
 
 [source,bash]
 ----
-kubectl label namespace default cluster-api.cattle.io/rancher-auto-import=true
+kubectl label namespace capi-clusters cluster-api.cattle.io/rancher-auto-import=true
 ----
 
 Labeling an individual cluster definition:

--- a/docs/next/modules/en/pages/tasks/capi-operator/capiprovider_resource.adoc
+++ b/docs/next/modules/en/pages/tasks/capi-operator/capiprovider_resource.adoc
@@ -26,7 +26,7 @@ apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
 metadata:
   name: aws-infra
-  namespace: default
+  namespace: capi-providers
 spec:
   name: aws
   type: infrastructure


### PR DESCRIPTION
It is bad practice to use default namespace, due to:
- lack of isolation
- security risks
- resources management
- scalability issues