### PR TITLE
Bump actions/upload-pages-artifact and actions/deploy-pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Generate Site
       run: make gh-pages
     - name: Upload Artifacts
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: build/site
     - name: Push the static site content to gh-pages branch
@@ -51,4 +51,4 @@ jobs:
         git push --force origin gh-pages
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
Should fix the build workflow: https://github.com/rancher/turtles-docs/actions/runs/13332210893

Note that deploy-pages@v4 is required by upload-pages-artifact@v3