### PR TITLE
Update Broken Links

### DIFF
--- a/docs/next/modules/en/pages/operator/airgapped.adoc
+++ b/docs/next/modules/en/pages/operator/airgapped.adoc
@@ -15,7 +15,7 @@ To install Cluster API providers in an air-gapped environment the following will
  ** Provide image overrides for each provider to pull images from an accessible image repository.
 . Configure {product_name} for an air-gapped environment:
  ** Collect and publish {product_name} images and publish to the private registry. https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#2-collect-the-cert-manager-image[Example of cert-manager installation for the reference].
- ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../operator/chart.adoc#cluster-api-operator-values[values.yaml].
+ ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../operator/chart.adoc#_cluster_api_operator_values[values.yaml].
  ** Provider image value for the Cluster API Operator helm chart dependency in https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml#L26[values.yaml]. Image values specified with the cluster-api-operator key will be passed along to the Cluster API Operator.
 
 == Example Usage

--- a/docs/next/modules/en/pages/operator/manual.adoc
+++ b/docs/next/modules/en/pages/operator/manual.adoc
@@ -2,7 +2,7 @@
 
 [CAUTION]
 ====
-In case you need to review the list of prerequisites (including `cert-manager`), you can refer to xref:../index.adoc#_prerequisites[this table].
+In case you need to review the list of prerequisites (including `cert-manager`), you can refer to xref:../tutorials/quickstart.adoc#_prerequisites[this table].
 ====
 
 

--- a/docs/next/modules/en/pages/tutorials/rancher.adoc
+++ b/docs/next/modules/en/pages/tutorials/rancher.adoc
@@ -25,6 +25,6 @@ helm install rancher rancher-stable/rancher
     --wait
 ----
 
-Replace `<rancher-hostname>` with the actual hostname of your `Rancher` server and use the `--version` option to specify the version of `Rancher` you want to install. In this case, use the xref:../index.adoc#_prerequisites[recommended] `Rancher` version for `{product_name}`.
+Replace `<rancher-hostname>` with the actual hostname of your `Rancher` server and use the `--version` option to specify the version of `Rancher` you want to install. In this case, use the xref:../tutorials/quickstart.adoc#_prerequisites[recommended] `Rancher` version for `{product_name}`.
 
 You are now ready to install and use {product_name}! 🎉

--- a/docs/next/modules/en/pages/user/clusterclass.adoc
+++ b/docs/next/modules/en/pages/user/clusterclass.adoc
@@ -26,7 +26,7 @@ This guide uses the https://github.com/rancher-sandbox/rancher-turtles-fleet-exa
 
 * Rancher Manager cluster with {product_name} installed
 * Cluster API providers installed for your scenario - we'll be using the Docker infrastructure and Kubeadm bootstrap/control plane providers in these instructions - see https://cluster-api.sigs.k8s.io/user/quick-start.html#initialization-for-common-providers[Initialization for common providers]
-* The *ClusterClass* feature enabled - see xref:./clusterclass.adoc#_enable_clusterclass[Enable ClusterClass]
+* The *ClusterClass* feature enabled - see xref:../operator/clusterclass.adoc#_enable_clusterclass[Enable ClusterClass]
 
 == Configure Rancher Manager
 

--- a/docs/v0.10/modules/en/pages/getting-started/air-gapped-environment.adoc
+++ b/docs/v0.10/modules/en/pages/getting-started/air-gapped-environment.adoc
@@ -14,7 +14,7 @@ To install Cluster API providers in an air-gapped environment the following will
  ** Provide image overrides for each provider to pull images from an accessible image repository.
 . Configure {product_name} for an air-gapped environment:
  ** Collect and publish {product_name} images and publish to the private registry. https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#2-collect-the-cert-manager-image[Example of cert-manager installation for the reference].
- ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#cluster-api-operator-values[values.yaml].
+ ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#_cluster_api_operator_values[values.yaml].
  ** Provider image value for the Cluster API Operator helm chart dependency in https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml#L26[values.yaml]. Image values specified with the cluster-api-operator key will be passed along to the Cluster API Operator.
 
 == Example Usage

--- a/docs/v0.11/modules/en/pages/getting-started/air-gapped-environment.adoc
+++ b/docs/v0.11/modules/en/pages/getting-started/air-gapped-environment.adoc
@@ -15,7 +15,7 @@ To install Cluster API providers in an air-gapped environment the following will
  ** Provide image overrides for each provider to pull images from an accessible image repository.
 . Configure {product_name} for an air-gapped environment:
  ** Collect and publish {product_name} images and publish to the private registry. https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#2-collect-the-cert-manager-image[Example of cert-manager installation for the reference].
- ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#cluster-api-operator-values[values.yaml].
+ ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#_cluster_api_operator_values[values.yaml].
  ** Provider image value for the Cluster API Operator helm chart dependency in https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml#L26[values.yaml]. Image values specified with the cluster-api-operator key will be passed along to the Cluster API Operator.
 
 == Example Usage

--- a/docs/v0.12/modules/en/pages/getting-started/air-gapped-environment.adoc
+++ b/docs/v0.12/modules/en/pages/getting-started/air-gapped-environment.adoc
@@ -15,7 +15,7 @@ To install Cluster API providers in an air-gapped environment the following will
  ** Provide image overrides for each provider to pull images from an accessible image repository.
 . Configure {product_name} for an air-gapped environment:
  ** Collect and publish {product_name} images and publish to the private registry. https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#2-collect-the-cert-manager-image[Example of cert-manager installation for the reference].
- ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#cluster-api-operator-values[values.yaml].
+ ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#_cluster_api_operator_values[values.yaml].
  ** Provider image value for the Cluster API Operator helm chart dependency in https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml#L26[values.yaml]. Image values specified with the cluster-api-operator key will be passed along to the Cluster API Operator.
 
 == Example Usage

--- a/docs/v0.13/modules/en/pages/getting-started/air-gapped-environment.adoc
+++ b/docs/v0.13/modules/en/pages/getting-started/air-gapped-environment.adoc
@@ -15,7 +15,7 @@ To install Cluster API providers in an air-gapped environment the following will
  ** Provide image overrides for each provider to pull images from an accessible image repository.
 . Configure {product_name} for an air-gapped environment:
  ** Collect and publish {product_name} images and publish to the private registry. https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#2-collect-the-cert-manager-image[Example of cert-manager installation for the reference].
- ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#cluster-api-operator-values[values.yaml].
+ ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#_cluster_api_operator_values[values.yaml].
  ** Provider image value for the Cluster API Operator helm chart dependency in https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml#L26[values.yaml]. Image values specified with the cluster-api-operator key will be passed along to the Cluster API Operator.
 
 == Example Usage

--- a/docs/v0.14/modules/en/pages/getting-started/air-gapped-environment.adoc
+++ b/docs/v0.14/modules/en/pages/getting-started/air-gapped-environment.adoc
@@ -15,7 +15,7 @@ To install Cluster API providers in an air-gapped environment the following will
  ** Provide image overrides for each provider to pull images from an accessible image repository.
 . Configure {product_name} for an air-gapped environment:
  ** Collect and publish {product_name} images and publish to the private registry. https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#2-collect-the-cert-manager-image[Example of cert-manager installation for the reference].
- ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#cluster-api-operator-values[values.yaml].
+ ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#_cluster_api_operator_values[values.yaml].
  ** Provider image value for the Cluster API Operator helm chart dependency in https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml#L26[values.yaml]. Image values specified with the cluster-api-operator key will be passed along to the Cluster API Operator.
 
 == Example Usage

--- a/docs/v0.15/modules/en/pages/getting-started/air-gapped-environment.adoc
+++ b/docs/v0.15/modules/en/pages/getting-started/air-gapped-environment.adoc
@@ -15,7 +15,7 @@ To install Cluster API providers in an air-gapped environment the following will
  ** Provide image overrides for each provider to pull images from an accessible image repository.
 . Configure {product_name} for an air-gapped environment:
  ** Collect and publish {product_name} images and publish to the private registry. https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#2-collect-the-cert-manager-image[Example of cert-manager installation for the reference].
- ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#cluster-api-operator-values[values.yaml].
+ ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#_cluster_api_operator_values[values.yaml].
  ** Provider image value for the Cluster API Operator helm chart dependency in https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml#L26[values.yaml]. Image values specified with the cluster-api-operator key will be passed along to the Cluster API Operator.
 
 == Example Usage

--- a/docs/v0.16/modules/en/pages/getting-started/air-gapped-environment.adoc
+++ b/docs/v0.16/modules/en/pages/getting-started/air-gapped-environment.adoc
@@ -15,7 +15,7 @@ To install Cluster API providers in an air-gapped environment the following will
  ** Provide image overrides for each provider to pull images from an accessible image repository.
 . Configure {product_name} for an air-gapped environment:
  ** Collect and publish {product_name} images and publish to the private registry. https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#2-collect-the-cert-manager-image[Example of cert-manager installation for the reference].
- ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#cluster-api-operator-values[values.yaml].
+ ** Provide fetch configuration and image values for `core` and `caprke2` providers in xref:../reference-guides/rancher-turtles-chart/values.adoc#_cluster_api_operator_values[values.yaml].
  ** Provider image value for the Cluster API Operator helm chart dependency in https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml#L26[values.yaml]. Image values specified with the cluster-api-operator key will be passed along to the Cluster API Operator.
 
 == Example Usage


### PR DESCRIPTION
Hello team! Updating some broken links I found in the `next` version while I was doing some prep to port over the restructure to the product docs. Also noting one link in the `airgapped.adoc/air-gapped-environment.adoc` pages needed to be updated across versions. Please let me know if there are any questions, thank you!