### PR TITLE
Updatecli revert releasepost version bump

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -21,9 +21,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install updatecli"
-        uses: "updatecli/updatecli-action@v2.78.1"
-        with:
-          version: "v0.92.0"
+        uses: "updatecli/updatecli-action@v2"
         
       - name: "Install Releasepost"
         uses: "updatecli/releasepost-action@v0.4.0"

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -26,7 +26,7 @@ jobs:
           version: "v0.92.0"
         
       - name: "Install Releasepost"
-        uses: "updatecli/releasepost-action@v0.5.0"
+        uses: "updatecli/releasepost-action@v0.4.0"
 
       - name: Run Updatecli in enforce mode
         run: "updatecli compose apply --file updatecli-compose.yaml"


### PR DESCRIPTION
# Description

During release we realized that `updatecli` workflows has been failing for some time now and, after narrowing it down, it looks like it started when dependabot bumped the action's version. For now, let's try to revert this bump and keep the previous version as it looks like the current one is behaving differently when no changed files are detected (which is the case where we see failures). Other projects that use this tool, like Fleet, are also still on the version we're reverting to.

Please, refer to the issue for more context on this and links to the specific action executions where this was first spotted. 

Fixes #235 