### PR TITLE
Updating Components Version - v0.17/next

### DIFF
--- a/docs/next/modules/en/pages/tutorials/quickstart.adoc
+++ b/docs/next/modules/en/pages/tutorials/quickstart.adoc
@@ -33,7 +33,7 @@ Before you can install {product_name}, you need to have the following components
 
 == Components Versions
 
-This table lists the version of the components installed with the latest version `v0.16.0` of {product_name}:
+This table lists the version of the components installed with the latest version `v0.17.0` of {product_name}:
 
 [TIP]
 ====
@@ -44,13 +44,13 @@ If you're customizing the installation parameters, please make sure that you are
 | Name | Version 
 
 | Cluster API Operator
-| `v0.16.0`
+| `v0.17.0`
 
 | Cluster API
-| `v1.9.4`
+| `v1.9.5`
 
 | Cluster API Provider RKE2
-| `v0.11.0`
+| `v0.12.0`
 |===
 
 == Install {product_name} using Rancher Dashboard

--- a/docs/v0.17/modules/en/pages/tutorials/quickstart.adoc
+++ b/docs/v0.17/modules/en/pages/tutorials/quickstart.adoc
@@ -33,7 +33,7 @@ Before you can install {product_name}, you need to have the following components
 
 == Components Versions
 
-This table lists the version of the components installed with the latest version `v0.16.0` of {product_name}:
+This table lists the version of the components installed with the latest version `v0.17.0` of {product_name}:
 
 [TIP]
 ====
@@ -44,13 +44,13 @@ If you're customizing the installation parameters, please make sure that you are
 | Name | Version 
 
 | Cluster API Operator
-| `v0.16.0`
+| `v0.17.0`
 
 | Cluster API
-| `v1.9.4`
+| `v1.9.5`
 
 | Cluster API Provider RKE2
-| `v0.11.0`
+| `v0.12.0`
 |===
 
 == Install {product_name} using Rancher Dashboard


### PR DESCRIPTION
Updating the components version for v0.17/next as it is still currently displaying v0.16 items. Reference: https://github.com/rancher/turtles/releases/tag/v0.17.0