### PR TITLE
Fix rendering issue with tab usage

### DIFF
--- a/docs/next/modules/en/pages/tutorials/first-cluster.adoc
+++ b/docs/next/modules/en/pages/tutorials/first-cluster.adoc
@@ -24,9 +24,7 @@ By inspecting the contents of this repository, you will find:
 . *fleet.yaml* is used to specify the configuration options for Fleet. In this case it's declaring that the cluster definition should be added to the `default` namespace.
 
 [NOTE]
-====
 If you prefer, you can create your own Fleet repository using the same base structure.
-====
 
 *Use Rancher UI to add your Fleet repository*
 


### PR DESCRIPTION
Latest [changes](https://github.com/rancher/turtles-docs/commit/2d82680c044bc69649604dd464d7c1b8a9ef77f1) broke the tutorials page only in the `next` version of docs (v0.17 is fine):

![image](https://github.com/user-attachments/assets/ecbd34f3-8f93-4ebe-a0e2-69ff360741da)

and this PR should fix it. Verified it locally:
![image](https://github.com/user-attachments/assets/323c9d30-7293-4315-afcd-c8d084d7a197)
