### PR TITLE
Add create namespace command for cluster examples

### DIFF
--- a/docs/next/modules/en/pages/user/clusters.adoc
+++ b/docs/next/modules/en/pages/user/clusters.adoc
@@ -323,6 +323,7 @@ curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs
 +
 [source,bash]
 ----
+kubectl create namespace ${NAMESPACE}
 kubectl create -f cluster1.yaml
 ----
 
@@ -355,7 +356,8 @@ curl -s https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-a
 +
 [source,bash]
 ----
- kubectl create -f cluster1.yaml
+kubectl create namespace ${NAMESPACE}
+kubectl create -f cluster1.yaml
 ----
 +
 . Deploy CNI
@@ -378,8 +380,8 @@ export RKE2_VERSION=v1.30.2+rke2r1
 export RKE2_CNI=calico
 export KUBERNETES_VERSION=v1.30.4 # needed for the CAPI Docker provider to use proper image
 
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-rke2.yaml -o template-docker-rke2.yaml
-envsubst '${NAMESPACE} ${CLUSTER_NAME} ${WORKER_MACHINE_COUNT} ${RKE2_VERSION} ${RKE2_CNI} ${CONTROL_PLANE_MACHINE_COUNT} ${KUBERNETES_VERSION}' < template-docker-rke2.yaml > docker-rke2.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-rke2.yaml -o docker-rke2.yaml
+envsubst '${NAMESPACE} ${CLUSTER_NAME} ${WORKER_MACHINE_COUNT} ${RKE2_VERSION} ${RKE2_CNI} ${CONTROL_PLANE_MACHINE_COUNT} ${KUBERNETES_VERSION}' < template-docker-rke2.yaml > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
@@ -419,6 +421,7 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 +
 [source,bash]
 ----
+kubectl create namespace ${NAMESPACE}
 kubectl create -f cluster1.yaml 
 ----
 +
@@ -470,6 +473,7 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 +
 [source,bash]
 ----
+kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
 
@@ -519,6 +523,7 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 +
 [source,bash]
 ----
+kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
 
@@ -554,6 +559,7 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 +
 [source,bash]
 ----
+kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
 
@@ -584,6 +590,7 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 +
 [source,bash]
 ----
+kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
 
@@ -616,6 +623,7 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 +
 [source,bash]
 ----
+kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
 


### PR DESCRIPTION
Fixing examples from documentation with adding `kubectl create namespace` command