### PR TITLE
Omit default namespace

### DIFF
--- a/docs/next/modules/en/pages/user/clusterclass.adoc
+++ b/docs/next/modules/en/pages/user/clusterclass.adoc
@@ -67,7 +67,6 @@ metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: cluster-identity
-  namespace: default
 spec:
   allowedNamespaces: {}
   clientID: <AZURE_APP_ID>


### PR DESCRIPTION
This makes it consistent with the Cluster definition just below, and does not make assumptions on the namespace used by the user.