### PR TITLE
Bump `releasepost` policy to align with latest action version

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '0 * * * *'
+    - cron: '0 12 * * *'
 
 permissions:
   contents: write

--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -7,7 +7,7 @@ policies:
   # 
   # Instruction to retrieve your PAT is documented on https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
   - name: Handle releasepost
-    policy: ghcr.io/salasberryfin/rancherlabs-policies/releasepost:0.2.0@sha256:2ab7a5edc38a30672184feffbea19805513ffe1c4e174bf3430cbdfdf4698f0f 
+    policy: ghcr.io/salasberryfin/rancherlabs-policies/releasepost:0.3.0@sha256:2fb468a760363ab724b8a4fefe62cded701647b6de7af10b73179810e1bb2451 
     values:
       - updatecli/values.d/scm.yaml
       - updatecli/values.d/turtles.yaml


### PR DESCRIPTION
# Description

The latest version of the `releasepost` GH Action requires minor changes on exit codes in the policy. This change should fix recent failures in the workflow, which runs daily.