### PR TITLE
[v0.18/Next] Updating Overview and Clusters Page

### DIFF
--- a/docs/next/modules/en/pages/index.adoc
+++ b/docs/next/modules/en/pages/index.adoc
@@ -40,7 +40,7 @@ If you are interested in contributing to {product_name}, this section will guide
 
 === Troubleshooting
 
-This section covers basic troubleshooting approaches for issues related to Rancher Turtles, Cluster API (CAPI), and CAPI providers the xref:./troubleshooting/troubleshooting.adoc[troubleshooting]
+This section covers basic xref:./troubleshooting/troubleshooting.adoc[troubleshooting approaches] for issues related to Rancher Turtles, Cluster API (CAPI), and CAPI providers.
 
 === Security
 

--- a/docs/next/modules/en/pages/user/clusters.adoc
+++ b/docs/next/modules/en/pages/user/clusters.adoc
@@ -348,7 +348,7 @@ export RKE2_CNI=calico
 export KUBERNETES_VERSION={kubernetes-version} # needed for the CAPI Docker provider to use proper image
 
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-rke2.yaml -o docker-rke2.yaml
-envsubst '${NAMESPACE} ${CLUSTER_NAME} ${WORKER_MACHINE_COUNT} ${RKE2_VERSION} ${RKE2_CNI} ${CONTROL_PLANE_MACHINE_COUNT} ${KUBERNETES_VERSION}' < template-docker-rke2.yaml > cluster1.yaml
+envsubst '${NAMESPACE} $\{CLUSTER_NAME} $\{WORKER_MACHINE_COUNT} $\{RKE2_VERSION} $\{RKE2_CNI} $\{CONTROL_PLANE_MACHINE_COUNT} $\{KUBERNETES_VERSION}' < template-docker-rke2.yaml > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
@@ -529,7 +529,7 @@ GCP GKE::
 +
 To generate the YAML for the cluster, do the following:
 +
-[source,bash]
+[source,bash,subs=attributes+]
 ----
 export CLUSTER_NAME={cluster-name}
 export NAMESPACE={namespace}

--- a/docs/v0.18/modules/en/pages/index.adoc
+++ b/docs/v0.18/modules/en/pages/index.adoc
@@ -40,7 +40,7 @@ If you are interested in contributing to {product_name}, this section will guide
 
 === Troubleshooting
 
-This section covers basic troubleshooting approaches for issues related to Rancher Turtles, Cluster API (CAPI), and CAPI providers the xref:./troubleshooting/troubleshooting.adoc[troubleshooting]
+This section covers basic xref:./troubleshooting/troubleshooting.adoc[troubleshooting approaches] for issues related to Rancher Turtles, Cluster API (CAPI), and CAPI providers.
 
 === Security
 

--- a/docs/v0.18/modules/en/pages/user/clusters.adoc
+++ b/docs/v0.18/modules/en/pages/user/clusters.adoc
@@ -348,7 +348,7 @@ export RKE2_CNI=calico
 export KUBERNETES_VERSION={kubernetes-version} # needed for the CAPI Docker provider to use proper image
 
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-rke2.yaml -o docker-rke2.yaml
-envsubst '${NAMESPACE} ${CLUSTER_NAME} ${WORKER_MACHINE_COUNT} ${RKE2_VERSION} ${RKE2_CNI} ${CONTROL_PLANE_MACHINE_COUNT} ${KUBERNETES_VERSION}' < template-docker-rke2.yaml > cluster1.yaml
+envsubst '${NAMESPACE} $\{CLUSTER_NAME} $\{WORKER_MACHINE_COUNT} $\{RKE2_VERSION} $\{RKE2_CNI} $\{CONTROL_PLANE_MACHINE_COUNT} $\{KUBERNETES_VERSION}' < template-docker-rke2.yaml > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
@@ -529,7 +529,7 @@ GCP GKE::
 +
 To generate the YAML for the cluster, do the following:
 +
-[source,bash]
+[source,bash,subs=attributes+]
 ----
 export CLUSTER_NAME={cluster-name}
 export NAMESPACE={namespace}


### PR DESCRIPTION
Updating the Overview page troubleshooting link and updating the Clusters page that had a missing attribute setting. Additionally escaped the variables on the Clusters page as they were producing a [warning missing attribute error](https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#missing:~:text=asciidoctor%3A%20WARNING%3A%20skipping%20reference%20to%20missing%20attribute%3A%20XYZ). I've updated these items in the [v0.18 docs port PR](https://github.com/rancher/turtles-product-docs/pull/39) as well.