### PR TITLE
Add RKE2+EC2 docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 .vscode/
 .DS_Store
 package-lock.json
+

--- a/docs/next/modules/en/pages/user/clusterclass.adoc
+++ b/docs/next/modules/en/pages/user/clusterclass.adoc
@@ -365,7 +365,7 @@ spec:
 
 AWS Kubeadm::
 +
-* An AWS ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
+* An AWS Kubeadm ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
 +
 [source,bash]
 ----
@@ -427,6 +427,76 @@ spec:
     - name: workerMachineType
       value: <AWS_NODE_MACHINE_TYPE>
     version: v1.31.0
+    workers:
+      machineDeployments:
+      - class: default-worker
+        name: md-0
+        replicas: 1
+----
+
+AWS RKE2::
++
+[WARNING]
+====
+Before creating an AWS+RKE2 workload cluster, it is required to either build an AMI for the RKE2 version that is going to be installed on the cluster or find one that will work for non-airgapped installations. 
+You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
+====
++
+* An AWS RKE2 ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
++
+[source,bash]
+----
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
+----
++
+* The https://github.com/kubernetes/cloud-provider-aws[Cloud Controller Manager AWS] will need to be installed on each downstream Cluster for the nodes to be functional. +
+* Additionally, we will also enable https://github.com/kubernetes-sigs/aws-ebs-csi-driver[AWS EBS CSI Driver]. +
++
+We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
+This Add-on provider is installed by default with {product_name}. +
+Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. This will take care of deploying Calico and the EBS CSI Driver in the workload cluster. +
++
+[source,bash]
+----
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/aws/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/aws-helm/helm-chart.yaml
+----
++
+* Create the AWS Cluster from the example ClusterClass +
++ 
+Note that some variables are left to the user to substitute. +
++
+[source,yaml]
+----
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cloud-provider: aws
+    csi: aws-ebs-csi-driver
+    cluster-api.cattle.io/rancher-auto-import: "true"
+  name: aws-quickstart
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  topology:
+    class: aws-rke2-example
+    controlPlane:
+      replicas: 1
+    variables:
+    - name: region
+      value: ${AWS_REGION}
+    - name: sshKeyName
+      value: ${AWS_SSH_KEY_NAME}
+    - name: controlPlaneMachineType
+      value: ${AWS_RKE2_CONTROL_PLANE_MACHINE_TYPE}
+    - name: workerMachineType
+      value: ${AWS_RKE2_NODE_MACHINE_TYPE}
+    - name: amiID
+      value: ${AWS_AMI_ID}
+    version: ${RKE2_VERSION}
     workers:
       machineDeployments:
       - class: default-worker
@@ -768,3 +838,14 @@ spec:
       value: <KUBE_VIP_INTERFACE>
 ----
 ======
+
+
+== Optionally Mark Namespace for Auto-Import
+
+To automatically import a CAPI cluster into Rancher Manager, you can label a namespace so all clusters contained in it are imported.
+
+[source,bash]
+----
+export NAMESPACE=default
+kubectl label namespace $NAMESPACE cluster-api.cattle.io/rancher-auto-import=true
+----

--- a/docs/next/modules/en/pages/user/clusters.adoc
+++ b/docs/next/modules/en/pages/user/clusters.adoc
@@ -10,7 +10,7 @@ Keep in mind that most Cluster API Providers are upstream projects maintained by
 
 [tabs]
 ======
-AWS EKS/RKE2/Kubeadm::
+AWS::
 +
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
@@ -118,7 +118,7 @@ spec:
 
 Docker RKE2/Kubeadm::
 +
-* Following installation guide was moved here xref:../user/clusterclass.adoc[here]
+* You can follow the installation guide xref:../user/clusterclass.adoc[here]
 
 vSphere RKE2/Kubeadm::
 +
@@ -202,88 +202,19 @@ spec:
 ======
 AWS EC2 RKE2::
 +
-Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
-+
-We recommend you refer to the CAPRKE2 repository where you can find a https://github.com/rancher/cluster-api-provider-rke2/tree/main/examples/templates/aws[samples folder] with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters.
-+
-We will use the `internal` one for this guide, however the same steps apply for `external`. 
-+
-To generate the YAML for the cluster, do the following:
-+
-. Open a terminal and run the following: 
-+
-[source,bash,subs=attributes+]
-----
-export CLUSTER_NAME={cluster-name}
-export NAMESPACE={namespace}
-export CONTROL_PLANE_MACHINE_COUNT={control-plane-machine-count}
-export WORKER_MACHINE_COUNT={worker-machine-count}
-export RKE2_VERSION={kubernetes-version}+rke2r1
-export AWS_NODE_MACHINE_TYPE=t3a.large 
-export AWS_CONTROL_PLANE_MACHINE_TYPE=t3a.large 
-export AWS_SSH_KEY_NAME="aws-ssh-key" 
-export AWS_REGION="aws-region" 
-export AWS_AMI_ID="ami-id" 
-
-curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/templates/aws/cluster-template.yaml | envsubst > cluster1.yaml
-----
-+
-. View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
-+
-> The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-
-. Create the cluster using kubectl
-+
-[source,bash]
-----
-kubectl create namespace ${NAMESPACE}
-kubectl create -f cluster1.yaml
-----
+* You can follow the installation guide xref:../user/clusterclass.adoc[here]
 
 AWS EC2 Kubeadm::
 +
-To generate the YAML for the cluster, do the following:
-+
-. Open a terminal and run the following:
-+
-[source,bash,subs=attributes+]
-----
-export CLUSTER_NAME={cluster-name}
-export NAMESPACE={namespace}
-export AWS_CONTROL_PLANE_MACHINE_TYPE=t3.large
-export AWS_NODE_MACHINE_TYPE=t3.large
-export AWS_SSH_KEY_NAME="aws-ssh-key" 
-export AWS_REGION="aws-region"
-export KUBERNETES_VERSION={kubernetes-version}
-export CONTROL_PLANE_MACHINE_COUNT={control-plane-machine-count}
-export WORKER_MACHINE_COUNT={worker-machine-count}
-
-curl -s https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/refs/heads/main/templates/cluster-template.yaml | envsubst > cluster1.yaml
-----
-+
-. View **cluster1.yaml** to ensure there are no tokens (i.e. SSH keys or cloud credentials). You can make any changes you want as well. 
-+
-> The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
- 
-. Create the cluster using kubectl
-+
-[source,bash]
-----
-kubectl create namespace ${NAMESPACE}
-kubectl create -f cluster1.yaml
-----
-+
-. Deploy CNI
-+
-> Once cluster is created a CNI is required for Nodes to become ready. You can refer to Cluster API documentation for example CNI installation https://cluster-api.sigs.k8s.io/user/quick-start#deploy-a-cni-solution[here].
+* You can follow the installation guide xref:../user/clusterclass.adoc[here]
 
 Docker RKE2::
 +
-* Following installation guide was moved here xref:../user/clusterclass.adoc[here]
+* You can follow the installation guide xref:../user/clusterclass.adoc[here]
 
 Docker Kubeadm::
 +
-* Following installation guide was moved here xref:../user/clusterclass.adoc[here]
+* You can follow the installation guide xref:../user/clusterclass.adoc[here]
 
 vSphere RKE2::
 +
@@ -473,12 +404,15 @@ Labeling a namespace:
 
 [source,bash]
 ----
-kubectl label namespace capi-clusters cluster-api.cattle.io/rancher-auto-import=true
+export NAMESPACE=default
+kubectl label namespace $NAMESPACE cluster-api.cattle.io/rancher-auto-import=true
 ----
 
 Labeling an individual cluster definition:
 
 [source,bash]
 ----
-kubectl label cluster.cluster.x-k8s.io -n default cluster1 cluster-api.cattle.io/rancher-auto-import=true
+export CLUSTER_NAME=cluster1
+export NAMESPACE=default
+kubectl label cluster.cluster.x-k8s.io -n $NAMESPACE $CLUSTER_NAME cluster-api.cattle.io/rancher-auto-import=true
 ----

--- a/docs/v0.19/modules/en/pages/user/clusters.adoc
+++ b/docs/v0.19/modules/en/pages/user/clusters.adoc
@@ -118,7 +118,7 @@ spec:
 
 Docker RKE2/Kubeadm::
 +
-* Following installation guide was moved here xref:../user/clusterclass.adoc[here]
+* You can follow the installation guide xref:../user/clusterclass.adoc[here]
 
 vSphere RKE2/Kubeadm::
 +
@@ -279,11 +279,11 @@ kubectl create -f cluster1.yaml
 
 Docker RKE2::
 +
-* Following installation guide was moved here xref:../user/clusterclass.adoc[here]
+* You can follow the installation guide xref:../user/clusterclass.adoc[here]
 
 Docker Kubeadm::
 +
-* Following installation guide was moved here xref:../user/clusterclass.adoc[here]
+* You can follow the installation guide xref:../user/clusterclass.adoc[here]
 
 vSphere RKE2::
 +


### PR DESCRIPTION
Add docs for creating an RKE2 cluster using EC2 instances, all steps were verified manually, and docs were deployed locally to ensure they render correctly.
Fixes https://github.com/rancher/turtles/issues/1196