### PR TITLE
Run Rancher Turtles documentation GH pages publication once a day

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Rancher Turtles documentation - publish to GitHub Pages with Lunr Search E
 on:
   # Runs every hour.
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
   # Runs whenever a change is pushed to the main branch
   push:
     branches: [main]


### PR DESCRIPTION
We can decrease the number of runs to once a day instead of hourly, since it uses personal GH handle as actor to run the workflow and that counts as a contribution in contributions graph