### PR TITLE
Bump Turtles version everywhere on new release 

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,0 +1,199 @@
+name: Update Component Versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      rancher_version:
+        description: 'Rancher version (e.g., v2.11.0)'
+        type: string
+      cluster_api_operator_version:
+        description: 'Cluster API Operator version (e.g., v0.18.1)'
+        type: string
+      cluster_api_version:
+        description: 'Cluster API version (e.g., v1.9.5)'
+        type: string
+      cluster_api_provider_rke2_version:
+        description: 'Cluster API Provider RKE2 version (e.g., v0.16.0)'
+        type: string
+      cert_manager_version:
+        description: 'Cert-manager version (e.g., v1.15.2)'
+        type: string
+      kubernetes_version:
+        description: 'Kubernetes cluster version (e.g., v1.30.0)'
+        type: string
+      helm_version:
+        description: 'Helm version (e.g., v3.17.1)'
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate dynamic config
+        run: |
+          cat > dynamic-config.json << 'EOF'
+          {
+            "rules": [
+          EOF
+          
+          first_rule=true
+          
+          if [[ -n "${{ inputs.rancher_version }}" ]]; then
+            if [[ "$first_rule" == "false" ]]; then echo "," >> dynamic-config.json; fi
+            cat >> dynamic-config.json << 'EOF'
+              {
+                "name": "Update Rancher version in prerequisites table",
+                "pattern": "\\| Rancher\\s*\\r?\\n\\| `v[0-9]+\\.[0-9]+\\.[0-9]+`",
+                "replacement": "| Rancher\n| `%s`",
+                "version": "${{ inputs.rancher_version }}"
+              },
+              {
+                "name": "Update RANCHER_VERSION environment variable",
+                "pattern": "RANCHER_VERSION: \"v[0-9]+\\.[0-9]+\\.[0-9]+\"",
+                "replacement": "RANCHER_VERSION: \"%s\"",
+                "version": "${{ inputs.rancher_version }}"
+              }
+          EOF
+            first_rule=false
+          fi
+          
+          if [[ -n "${{ inputs.cluster_api_operator_version }}" ]]; then
+            if [[ "$first_rule" == "false" ]]; then echo "," >> dynamic-config.json; fi
+            cat >> dynamic-config.json << 'EOF'
+              {
+                "name": "Update Cluster API Operator version in prerequisites table",
+                "pattern": "\\| Cluster API Operator\\s*\\r?\\n\\| `v[0-9]+\\.[0-9]+\\.[0-9]+`",
+                "replacement": "| Cluster API Operator\n| `%s`",
+                "version": "${{ inputs.cluster_api_operator_version }}"
+              }
+          EOF
+            first_rule=false
+          fi
+          
+          if [[ -n "${{ inputs.cluster_api_version }}" ]]; then
+            if [[ "$first_rule" == "false" ]]; then echo "," >> dynamic-config.json; fi
+            cat >> dynamic-config.json << 'EOF'
+              {
+                "name": "Update Cluster API version in prerequisites table",
+                "pattern": "\\| Cluster API\\s*\\r?\\n\\| `v[0-9]+\\.[0-9]+\\.[0-9]+`",
+                "replacement": "| Cluster API\n| `%s`",
+                "version": "${{ inputs.cluster_api_version }}"
+              }
+          EOF
+            first_rule=false
+          fi
+          
+          if [[ -n "${{ inputs.cluster_api_provider_rke2_version }}" ]]; then
+            if [[ "$first_rule" == "false" ]]; then echo "," >> dynamic-config.json; fi
+            cat >> dynamic-config.json << 'EOF'
+              {
+                "name": "Update Cluster API Provider RKE2 version in prerequisites table",
+                "pattern": "\\| Cluster API Provider RKE2\\s*\\r?\\n\\| `v[0-9]+\\.[0-9]+\\.[0-9]+`",
+                "replacement": "| Cluster API Provider RKE2\n| `%s`",
+                "version": "${{ inputs.cluster_api_provider_rke2_version }}"
+              }
+          EOF
+            first_rule=false
+          fi
+          
+          if [[ -n "${{ inputs.cert_manager_version }}" ]]; then
+            if [[ "$first_rule" == "false" ]]; then echo "," >> dynamic-config.json; fi
+            cat >> dynamic-config.json << 'EOF'
+              {
+                "name": "Update Cert-manager version in prerequisites table",
+                "pattern": "\\| Cert-manager\\s*\\r?\\n\\| `v[0-9]+\\.[0-9]+\\.[0-9]+`",
+                "replacement": "| Cert-manager\n| `%s`",
+                "version": "${{ inputs.cert_manager_version }}"
+              }
+          EOF
+            first_rule=false
+          fi
+          
+          if [[ -n "${{ inputs.kubernetes_version }}" ]]; then
+            if [[ "$first_rule" == "false" ]]; then echo "," >> dynamic-config.json; fi
+            cat >> dynamic-config.json << 'EOF'
+              {
+                "name": "Update Kubernetes cluster version in prerequisites table",
+                "pattern": "\\| Kubernetes cluster\\s*\\r?\\n\\| `v[0-9]+\\.[0-9]+\\.[0-9]+`",
+                "replacement": "| Kubernetes cluster\n| `%s`",
+                "version": "${{ inputs.kubernetes_version }}"
+              }
+          EOF
+            first_rule=false
+          fi
+          
+          if [[ -n "${{ inputs.helm_version }}" ]]; then
+            if [[ "$first_rule" == "false" ]]; then echo "," >> dynamic-config.json; fi
+            cat >> dynamic-config.json << 'EOF'
+              {
+                "name": "Update Helm version in prerequisites table",
+                "pattern": "\\| Helm\\s*\\r?\\n\\| `v[0-9]+\\.[0-9]+\\.[0-9]+`",
+                "replacement": "| Helm\n| `%s`",
+                "version": "${{ inputs.helm_version }}"
+              }
+          EOF
+            first_rule=false
+          fi
+          
+          cat >> dynamic-config.json << 'EOF'
+            ]
+          }
+          EOF
+
+      - name: Apply version updates
+        run: |
+          if [[ -s dynamic-config.json ]] && [[ $(jq '.rules | length' dynamic-config.json) -gt 0 ]]; then
+            go run tools/setexampleversion/main.go -config=dynamic-config.json \
+              docs/next/modules/en/pages/operator/certificationsuite.adoc \
+              docs/next/modules/en/pages/tutorials/quickstart.adoc
+          else
+            echo "No rules to apply - skipping updates"
+          fi
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet docs/next/; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit changes
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          
+          # Create a descriptive commit message
+          commit_msg="Update component versions in docs/next"
+          if [[ -n "${{ inputs.rancher_version }}" ]]; then commit_msg+="\n- Rancher: ${{ inputs.rancher_version }}"; fi
+          if [[ -n "${{ inputs.cluster_api_operator_version }}" ]]; then commit_msg+="\n- Cluster API Operator: ${{ inputs.cluster_api_operator_version }}"; fi
+          if [[ -n "${{ inputs.cluster_api_version }}" ]]; then commit_msg+="\n- Cluster API: ${{ inputs.cluster_api_version }}"; fi
+          if [[ -n "${{ inputs.cluster_api_provider_rke2_version }}" ]]; then commit_msg+="\n- Cluster API Provider RKE2: ${{ inputs.cluster_api_provider_rke2_version }}"; fi
+          if [[ -n "${{ inputs.cert_manager_version }}" ]]; then commit_msg+="\n- Cert-manager: ${{ inputs.cert_manager_version }}"; fi
+          if [[ -n "${{ inputs.kubernetes_version }}" ]]; then commit_msg+="\n- Kubernetes: ${{ inputs.kubernetes_version }}"; fi
+          if [[ -n "${{ inputs.helm_version }}" ]]; then commit_msg+="\n- Helm: ${{ inputs.helm_version }}"; fi
+          
+          branch_name="update-component-versions-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b $branch_name
+          git add docs/next/
+          git commit -m "$commit_msg"
+          git push origin $branch_name
+          
+          echo -e "$commit_msg" > body
+          export body=$(cat body)
+          gh pr create --title 'Update component versions in documentation' --body "$body" --label "area/documentation"
+
+      - name: Cleanup
+        run: |
+          rm -f dynamic-config.json

--- a/.github/workflows/publish-version.yaml
+++ b/.github/workflows/publish-version.yaml
@@ -25,6 +25,14 @@ jobs:
           git fetch --tags
           echo "TRIMMED_TAG=${TAG#v}" >> $GITHUB_ENV
           echo "TAG=${TAG%.*}" >> $GITHUB_ENV
+      - name: Update example versions in documentation
+        run: |
+          go run tools/setexampleversion/main.go -version=v${{ env.TRIMMED_TAG }} \
+            docs/next/modules/en/pages/user/clusterclass.adoc \
+            docs/next/modules/en/pages/operator/certificationsuite.adoc \
+            docs/next/modules/en/pages/operator/manual.adoc \
+            docs/next/modules/en/pages/tutorials/quickstart.adoc
+            docs/next/modules/en/pages/user/clusters.adoc
       - name: Copy docs directory
         run: |
           mkdir -p docs/${TAG}
@@ -44,9 +52,6 @@ jobs:
       - name: Change display_version in antora.yml
         run: |
           sed -i "s/^display_version: .*/display_version: '$TAG'/"  docs/${TAG}/antora.yml
-      - name: Update example versions in documentation
-        run: |
-          go run tools/setexampleversion/main.go -version=v${{ env.TRIMMED_TAG }} docs/${{env.TAG}}/modules/en/pages/user/clusterclass.adoc
       - name: Commit changes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.adoc
+++ b/README.adoc
@@ -134,3 +134,73 @@ make ci
 ----
 
 This will run the build using the GitHub Pages playbook and the development playbook in sequence.
+
+[#turtles-version-updates-across-docs]
+== Turtles Version Updates Across Docs
+
+This section explains how Turtles documentation versions are managed and updated when new releases are published.
+
+[#automated-version-bumping]
+=== Automated Version Bumping
+
+The documentation repository automatically updates versions when a new Turtles release tag is pushed to the main repository. Here's how the process works:
+The version bump process is triggered automatically when:
+
+1. A new version tag (format: `v*`) is pushed to the rancher/turtles repository
+2. The GitHub workflow `.github/workflows/publish-version.yaml` detects the tag and starts the process
+
+[#what-gets-updated]
+==== What Gets Updated
+
+The automation updates several types of version references throughout the documentation:
+
+* **GitHub URLs**: Raw GitHub links are updated from `refs/heads/main` to `refs/tags/v{version}`
+* **Environment Variables**: `TURTLES_VERSION` values in code examples
+* **Helm Commands**: Version flags in `helm install` commands
+* **Component Tables**: Version references in component compatibility tables
+
+[#version-replacement-tool]
+==== Version Replacement Tool
+
+The repository includes a custom Go tool at `tools/setexampleversion/main.go` that handles version replacements:
+
+* **Configuration**: Uses `replace-rules.json` to define replacement patterns
+* **Flexible Rules**: Each rule specifies a regex pattern and replacement template
+
+Example usage:
+[,console]
+----
+go run tools/setexampleversion/main.go -version=v0.21.0 \
+  docs/v0.21/modules/en/pages/user/installation.adoc \
+  docs/v0.21/modules/en/pages/user/clusterclass.adoc
+----
+
+[#manual-version-updates]
+=== Manual Version Updates
+
+For manual version updates or testing:
+
+1. **Update the config**: Modify `replace-rules.json` if new replacement patterns are needed
+2. **Run the tool**: Execute the version replacement tool with the desired version
+3. **Review changes**: Check that all version references have been updated correctly
+4. **Test locally**: Build and preview the documentation to ensure everything works
+
+[#adding-new-version-patterns]
+=== Adding New Version Patterns
+
+When new version references are added to the documentation:
+
+1. **Identify the pattern**: Find the exact text pattern that needs version replacement
+2. **Add a rule**: Update `replace-rules.json` with a new replacement rule
+3. **Test the rule**: Run the tool to verify the pattern matches correctly
+4. **Document the change**: Update this README if the change affects the workflow
+
+Example rule structure:
+[,json]
+----
+{
+  "name": "Description of what this rule updates",
+  "pattern": "regex-pattern-to-match",
+  "replacement": "replacement-template-with-%s-placeholder"
+}
+----

--- a/README.adoc
+++ b/README.adoc
@@ -175,6 +175,15 @@ go run tools/setexampleversion/main.go -version=v0.21.0 \
   docs/v0.21/modules/en/pages/user/clusterclass.adoc
 ----
 
+[#component-version-updates]
+==== Component Version Updates
+
+For updating component versions (Rancher, Cluster API, etc.) in the prerequisites tables, the repository includes a reusable workflow at `.github/workflows/pre-release.yaml`. This workflow can be called from other workflows to selectively update component versions in the `docs/next/` directory:
+
+* **Selective Updates**: Only updates versions for components that are specified as inputs
+* **Automatic PR Creation**: Creates a pull request with the version changes
+* **Flexible Configuration**: Each component version can be updated independently
+
 [#manual-version-updates]
 === Manual Version Updates
 

--- a/docs/next/modules/en/pages/user/clusters.adoc
+++ b/docs/next/modules/en/pages/user/clusters.adoc
@@ -249,7 +249,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-rke2.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/legacy/vsphere-rke2.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -299,7 +299,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/legacy/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.

--- a/docs/v0.13/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/docs/v0.13/modules/en/pages/reference-guides/providers/howto.adoc
@@ -61,7 +61,7 @@ export AWS_CONTROL_PLANE_MACHINE_TYPE=t3a.large
 export AWS_SSH_KEY_NAME="aws-ssh-key" export AWS_REGION="aws-region" 
 export AWS_AMI_ID="ami-id" 
 
-curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/aws/cluster-template.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/templates/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.

--- a/docs/v0.14/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/docs/v0.14/modules/en/pages/reference-guides/providers/howto.adoc
@@ -61,7 +61,7 @@ export AWS_CONTROL_PLANE_MACHINE_TYPE=t3a.large
 export AWS_SSH_KEY_NAME="aws-ssh-key" export AWS_REGION="aws-region" 
 export AWS_AMI_ID="ami-id" 
 
-curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/aws/cluster-template.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/templates/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.

--- a/docs/v0.15/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/docs/v0.15/modules/en/pages/reference-guides/providers/howto.adoc
@@ -61,7 +61,7 @@ export AWS_CONTROL_PLANE_MACHINE_TYPE=t3a.large
 export AWS_SSH_KEY_NAME="aws-ssh-key" export AWS_REGION="aws-region" 
 export AWS_AMI_ID="ami-id" 
 
-curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/aws/cluster-template.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/templates/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.

--- a/docs/v0.16/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/docs/v0.16/modules/en/pages/reference-guides/providers/howto.adoc
@@ -61,7 +61,7 @@ export AWS_CONTROL_PLANE_MACHINE_TYPE=t3a.large
 export AWS_SSH_KEY_NAME="aws-ssh-key" export AWS_REGION="aws-region" 
 export AWS_AMI_ID="ami-id" 
 
-curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/aws/cluster-template.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/templates/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.

--- a/docs/v0.17/modules/en/pages/operator/certificationsuite.adoc
+++ b/docs/v0.17/modules/en/pages/operator/certificationsuite.adoc
@@ -83,7 +83,7 @@ variables:
   TURTLES_PATH: "turtles/rancher-turtles"
   TURTLES_REPO_NAME: "turtles"
   TURTLES_URL: https://rancher.github.io/turtles
-  TURTLES_VERSION: "v0.10.0"
+  TURTLES_VERSION: "v0.17.0"
   RANCHER_HOSTNAME: "localhost"
   RANCHER_FEATURES: ""
   RANCHER_PATH: "rancher-latest/rancher"

--- a/docs/v0.17/modules/en/pages/user/clusters.adoc
+++ b/docs/v0.17/modules/en/pages/user/clusters.adoc
@@ -377,7 +377,7 @@ export WORKER_MACHINE_COUNT=1
 export RKE2_VERSION=v1.30.2+rke2r1
 export KUBERNETES_VERSION=v1.30.4 # needed for the CAPI Docker provider to use proper image
 
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-rke2.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.17.0/test/e2e/data/cluster-templates/docker-rke2.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
@@ -405,7 +405,7 @@ export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.30.4
 
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.17.0/test/e2e/data/cluster-templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
@@ -456,7 +456,7 @@ export KUBERNETES_VERSION=v1.30.0
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-rke2.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.17.0/test/e2e/data/cluster-templates/vsphere-rke2.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -505,7 +505,7 @@ export KUBERNETES_VERSION=v1.30.0
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.17.0/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -540,7 +540,7 @@ export AZURE_TENANT_ID="xxx"
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/azure-aks-topology.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.17.0/test/e2e/data/cluster-templates/azure-aks-topology.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -570,7 +570,7 @@ export KUBERNETES_VERSION=v1.30.4
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.17.0/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -602,7 +602,7 @@ export WORKER_MACHINE_COUNT=1
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.17.0/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.

--- a/docs/v0.18/modules/en/pages/user/clusterclass.adoc
+++ b/docs/v0.18/modules/en/pages/user/clusterclass.adoc
@@ -95,7 +95,7 @@ Azure RKE2::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/rke2/clusterclass-rke2-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.18.0/examples/clusterclasses/azure/clusterclass-rke2-example.yaml
 ----
 +
 * Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
@@ -107,8 +107,8 @@ Two `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/azure/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.18.0/examples/applications/ccm/azure/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.18.0/examples/applications/cni/calico/helm-chart.yaml
 ----
 +
 * Create the Azure Cluster from the example ClusterClass +
@@ -162,7 +162,7 @@ Azure AKS::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/aks/clusterclass-aks-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.18.0/examples/clusterclasses/azure/clusterclass-aks-example.yaml
 ----
 +
 * Create the Azure AKS Cluster from the example ClusterClass +

--- a/docs/v0.18/modules/en/pages/user/clusters.adoc
+++ b/docs/v0.18/modules/en/pages/user/clusters.adoc
@@ -347,7 +347,7 @@ export RKE2_VERSION={kubernetes-version}+rke2r1
 export RKE2_CNI=calico
 export KUBERNETES_VERSION={kubernetes-version} # needed for the CAPI Docker provider to use proper image
 
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-rke2.yaml -o docker-rke2.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.18.0/test/e2e/data/cluster-templates/docker-rke2.yaml -o docker-rke2.yaml
 envsubst '${NAMESPACE} $\{CLUSTER_NAME} $\{WORKER_MACHINE_COUNT} $\{RKE2_VERSION} $\{RKE2_CNI} $\{CONTROL_PLANE_MACHINE_COUNT} $\{KUBERNETES_VERSION}' < template-docker-rke2.yaml > cluster1.yaml
 ----
 +
@@ -377,7 +377,7 @@ export CONTROL_PLANE_MACHINE_COUNT={control-plane-machine-count}
 export WORKER_MACHINE_COUNT={worker-machine-count}
 export KUBERNETES_VERSION={kubernetes-version}
 
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.18.0/test/e2e/data/cluster-templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
@@ -429,7 +429,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-rke2.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.18.0/test/e2e/data/cluster-templates/vsphere-rke2.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -479,7 +479,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.18.0/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -510,7 +510,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.18.0/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -543,7 +543,7 @@ export WORKER_MACHINE_COUNT={worker-machine-count}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.18.0/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.

--- a/docs/v0.19/modules/en/pages/user/clusterclass.adoc
+++ b/docs/v0.19/modules/en/pages/user/clusterclass.adoc
@@ -196,7 +196,7 @@ Azure RKE2::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/rke2/clusterclass-rke2-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/clusterclasses/azure/clusterclass-rke2-example.yaml
 ----
 +
 * Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
@@ -208,8 +208,8 @@ Two `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/azure/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/applications/ccm/azure/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/applications/cni/calico/helm-chart.yaml
 ----
 +
 * Create the Azure Cluster from the example ClusterClass +
@@ -263,7 +263,7 @@ Azure AKS::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/aks/clusterclass-aks-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/clusterclasses/azure/clusterclass-aks-example.yaml
 ----
 +
 * Create the Azure AKS Cluster from the example ClusterClass +
@@ -311,7 +311,7 @@ AWS Kubeadm::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/aws/kubeadm/clusterclass-kubeadm-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/clusterclasses/aws/clusterclass-kubeadm-example.yaml
 ----
 +
 * For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
@@ -324,9 +324,9 @@ The `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/aws/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/aws/calico/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/aws/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/applications/csi/aws/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/applications/cni/aws/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/applications/ccm/aws/fleet-bundle.yaml
 ----
 +
 * Create the AWS Cluster from the example ClusterClass +
@@ -376,7 +376,7 @@ Docker Kubeadm::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/kubeadm/clusterclass-docker-kubeadm.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/clusterclasses/docker/clusterclass-docker-kubeadm.yaml
 ----
 +
 * For this example we are also going to install Calico as the default CNI.
@@ -387,7 +387,7 @@ Two `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/applications/cni/calico/helm-chart.yaml
 ----
 +
 * Create the Docker Kubeadm Cluster from the example ClusterClass +
@@ -429,7 +429,7 @@ Docker RKE2::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/clusterclasses/docker/clusterclass-docker-rke2.yaml
 ----
 +
 * For this example we are also going to install Calico as the default CNI.
@@ -440,7 +440,7 @@ Two `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/applications/cni/calico/helm-chart.yaml
 ----
 +
 * Create the LoadBalancer ConfigMap for Docker RKEv2 Cluster +

--- a/docs/v0.19/modules/en/pages/user/clusters.adoc
+++ b/docs/v0.19/modules/en/pages/user/clusters.adoc
@@ -318,7 +318,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-rke2.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/legacy/vsphere-rke2.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -368,7 +368,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/examples/legacy/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -399,7 +399,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -432,7 +432,7 @@ export WORKER_MACHINE_COUNT={worker-machine-count}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.19.0/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.

--- a/docs/v0.20/modules/en/pages/operator/certificationsuite.adoc
+++ b/docs/v0.20/modules/en/pages/operator/certificationsuite.adoc
@@ -85,7 +85,7 @@ variables:
   TURTLES_PATH: "turtles/rancher-turtles"
   TURTLES_REPO_NAME: "turtles"
   TURTLES_URL: https://rancher.github.io/turtles
-  TURTLES_VERSION: "v0.19.0"
+  TURTLES_VERSION: "v0.20.0"
   RANCHER_HOSTNAME: "localhost"
   RANCHER_FEATURES: ""
   RANCHER_PATH: "rancher-latest/rancher"

--- a/docs/v0.20/modules/en/pages/user/clusterclass.adoc
+++ b/docs/v0.20/modules/en/pages/user/clusterclass.adoc
@@ -320,7 +320,7 @@ Azure RKE2::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/rke2/clusterclass-rke2-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/clusterclasses/azure/rke2/clusterclass-rke2-example.yaml
 ----
 +
 * Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
@@ -332,8 +332,8 @@ Two `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/azure/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/ccm/azure/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/cni/calico/helm-chart.yaml
 ----
 +
 * Create the Azure Cluster from the example ClusterClass +
@@ -387,7 +387,7 @@ Azure AKS::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/aks/clusterclass-aks-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/clusterclasses/azure/aks/clusterclass-aks-example.yaml
 ----
 +
 * Create the Azure AKS Cluster from the example ClusterClass +
@@ -435,7 +435,7 @@ AWS Kubeadm::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/aws/kubeadm/clusterclass-kubeadm-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/clusterclasses/aws/kubeadm/clusterclass-kubeadm-example.yaml
 ----
 +
 * For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
@@ -448,9 +448,9 @@ The `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/aws/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/aws/calico/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/aws/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/csi/aws/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/cni/aws/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/ccm/aws/helm-chart.yaml
 ----
 +
 * Create the AWS Cluster from the example ClusterClass +
@@ -506,7 +506,7 @@ You can follow the steps in the https://github.com/rancher/cluster-api-provider-
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
 ----
 +
 * The https://github.com/kubernetes/cloud-provider-aws[Cloud Controller Manager AWS] will need to be installed on each downstream Cluster for the nodes to be functional. +
@@ -519,8 +519,8 @@ The CNI selection can instead be configured using Cluster variables and it will 
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/aws/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/aws/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/csi/aws/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/ccm/aws/helm-chart.yaml
 ----
 +
 * Create the AWS Cluster from the example ClusterClass +
@@ -573,7 +573,7 @@ Docker Kubeadm::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/kubeadm/clusterclass-docker-kubeadm.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/clusterclasses/docker/kubeadm/clusterclass-docker-kubeadm.yaml
 ----
 +
 * For this example we are also going to install Calico as the default CNI.
@@ -584,7 +584,7 @@ Two `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/cni/calico/helm-chart.yaml
 ----
 +
 * Create the Docker Kubeadm Cluster from the example ClusterClass +
@@ -626,7 +626,7 @@ Docker RKE2::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
 ----
 +
 * For this example we are also going to install Calico as the default CNI.
@@ -637,14 +637,14 @@ Two `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/cni/calico/helm-chart.yaml
 ----
 +
 * Create the LoadBalancer ConfigMap for Docker RKEv2 Cluster +
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/lb/docker/configmap.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/lb/docker/configmap.yaml
 ----
 +
 * Create the Docker Kubeadm Cluster from the example ClusterClass +
@@ -691,7 +691,7 @@ vSphere Kubeadm::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/vsphere/kubeadm/clusterclass-kubeadm-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/clusterclasses/vsphere/kubeadm/clusterclass-kubeadm-example.yaml
 ----
 +
 * Additionally, the https://github.com/kubernetes/cloud-provider-vsphere[vSphere Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
@@ -704,15 +704,15 @@ Two `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/vsphere/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/ccm/vsphere/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/cni/calico/helm-chart.yaml
 ----
 +
 Since the vSphere CSI driver is not packaged in Helm, we are going to include its entire manifest in a Fleet Bundle, that will be applied to the downstream Cluster.
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/vsphere/bundle.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/csi/vsphere/bundle.yaml
 ----
 +
 * Cluster configuration
@@ -850,7 +850,7 @@ vSphere RKE2::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
 ----
 +
 * Additionally, the https://github.com/kubernetes/cloud-provider-vsphere[vSphere Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
@@ -863,15 +863,15 @@ Two `HelmApps` need to be created first, to be applied on the new Cluster via la
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/vsphere/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/ccm/vsphere/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/cni/calico/helm-chart.yaml
 ----
 +
 Since the vSphere CSI driver is not packaged in Helm, we are going to include its entire manifest in a Fleet Bundle, that will be applied to the downstream Cluster.
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/vsphere/bundle.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/applications/csi/vsphere/bundle.yaml
 ----
 +
 * Cluster configuration

--- a/docs/v0.20/modules/en/pages/user/clusters.adoc
+++ b/docs/v0.20/modules/en/pages/user/clusters.adoc
@@ -249,7 +249,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-rke2.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/legacy/vsphere-rke2.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -299,7 +299,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/examples/legacy/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -330,7 +330,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
@@ -363,7 +363,7 @@ export WORKER_MACHINE_COUNT={worker-machine-count}
 +
 [source,bash]
 ----
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
+curl -s https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.20.0/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
 ----
 +
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.

--- a/replace-rules.json
+++ b/replace-rules.json
@@ -1,0 +1,24 @@
+{
+    "rules": [
+      {
+        "name": "Update Turtles raw GitHub links",
+        "pattern": "https://raw\\.githubusercontent\\.com/rancher/turtles/refs/heads/main/",
+        "replacement": "https://raw.githubusercontent.com/rancher/turtles/refs/tags/%s/"
+      },
+      {
+        "name": "Update TURTLES_VERSION environment variable",
+        "pattern": "TURTLES_VERSION: \"v[0-9]+\\.[0-9]+\\.[0-9]+\"",
+        "replacement": "TURTLES_VERSION: \"%s\""
+      },
+      {
+        "name": "Update helm install version flag",
+        "pattern": "helm install rancher-turtles turtles/rancher-turtles --version v[0-9]+\\.[0-9]+\\.[0-9]+",
+        "replacement": "helm install rancher-turtles turtles/rancher-turtles --version %s"
+      },
+      {
+        "name": "Update version in component table description",
+        "pattern": "This table lists the version of the components installed with the latest version `v[0-9]+\\.[0-9]+\\.[0-9]+` of \\{product_name\\}:",
+        "replacement": "This table lists the version of the components installed with the latest version `%s` of {product_name}:"
+      }
+    ]
+  }

--- a/tools/setexampleversion/main.go
+++ b/tools/setexampleversion/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -8,41 +9,74 @@ import (
 	"strings"
 )
 
+type ReplacementRule struct {
+	Name        string `json:"name"`
+	Pattern     string `json:"pattern"`
+	Replacement string `json:"replacement"`
+	Version     string `json:"version,omitempty"`
+}
+
+type Config struct {
+	DefaultVersion string            `json:"default_version,omitempty"`
+	Rules          []ReplacementRule `json:"rules"`
+}
+
 func main() {
-	version := flag.String("version", "", "version tag to replace with (e.g., v0.20.0)")
+	version := flag.String("version", "", "default version to replace with (e.g., v0.20.0)")
+	configFile := flag.String("config", "replace-rules.json", "JSON config file path")
 	flag.Parse()
 
-	if *version == "" {
-		fmt.Fprintf(os.Stderr, "Error: version flag is required\n")
-		fmt.Fprintf(os.Stderr, "Usage: %s -version=v0.20.0 file1.adoc file2.adoc\n", os.Args[0])
+	configData, err := os.ReadFile(*configFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading config file %s: %v\n", *configFile, err)
+		os.Exit(1)
+	}
+
+	var config Config
+	if err := json.Unmarshal(configData, &config); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing config file: %v\n", err)
+		os.Exit(1)
+	}
+
+	defaultVersion := *version
+	if defaultVersion == "" && config.DefaultVersion != "" {
+		defaultVersion = config.DefaultVersion
+	}
+	if defaultVersion == "" {
+		fmt.Fprintf(os.Stderr, "Error: version must be provided via -version flag or default_version in config\n")
 		os.Exit(1)
 	}
 
 	files := flag.Args()
 	if len(files) == 0 {
 		fmt.Fprintf(os.Stderr, "Error: no files specified\n")
-		fmt.Fprintf(os.Stderr, "Usage: %s -version=v0.20.0 file1.adoc file2.adoc\n", os.Args[0])
-		os.Exit(1)
-	}
-
-	if !strings.HasPrefix(*version, "v") {
-		fmt.Fprintf(os.Stderr, "Error: version must start with 'v' (e.g., v0.20.0)\n")
+		fmt.Fprintf(os.Stderr, "Usage: %s -config=config.json -version=v0.20.0 file1.adoc file2.adoc\n", os.Args[0])
 		os.Exit(1)
 	}
 
 	totalReplacements := 0
 	for _, file := range files {
-		replacements := updateFile(file, *version)
-		if replacements > 0 {
-			fmt.Printf("Updated %d links in %s\n", replacements, file)
-			totalReplacements += replacements
+		fileReplacements := 0
+
+		for _, rule := range config.Rules {
+			ruleVersion := defaultVersion
+			if rule.Version != "" {
+				ruleVersion = rule.Version
+			}
+			replacements := updateFileWithRule(file, rule, ruleVersion)
+			fileReplacements += replacements
+		}
+
+		if fileReplacements > 0 {
+			fmt.Printf("Updated %d links in %s\n", fileReplacements, file)
+			totalReplacements += fileReplacements
 		}
 	}
 
 	fmt.Printf("Done. Total replacements: %d\n", totalReplacements)
 }
 
-func updateFile(filename, version string) int {
+func updateFileWithRule(filename string, rule ReplacementRule, version string) int {
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", filename, err)
@@ -50,7 +84,7 @@ func updateFile(filename, version string) int {
 	}
 
 	originalContent := string(content)
-	updatedContent := updateRawGitHubLinks(originalContent, version)
+	updatedContent := applyRule(originalContent, rule, version)
 
 	if originalContent == updatedContent {
 		return 0
@@ -65,12 +99,15 @@ func updateFile(filename, version string) int {
 	return countReplacements(originalContent, updatedContent)
 }
 
-func updateRawGitHubLinks(content, version string) string {
-	rawGitHubRegex := regexp.MustCompile(`https://raw\.githubusercontent\.com/rancher/turtles/refs/heads/main/`)
+func applyRule(content string, rule ReplacementRule, version string) string {
+	regex, err := regexp.Compile(rule.Pattern)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error compiling regex for rule %s: %v\n", rule.Name, err)
+		return content
+	}
 
-	replacement := fmt.Sprintf("https://raw.githubusercontent.com/rancher/turtles/refs/tags/%s/", version)
-
-	return rawGitHubRegex.ReplaceAllString(content, replacement)
+	replacement := fmt.Sprintf(rule.Replacement, version)
+	return regex.ReplaceAllString(content, replacement)
 }
 
 func countReplacements(original, updated string) int {

--- a/tools/verifybrokenlinks/main.go
+++ b/tools/verifybrokenlinks/main.go
@@ -83,7 +83,7 @@ func extractLinks(docsDir string) ([]URLOccurrence, []string) {
 	var occurrences []URLOccurrence
 	uniqueURLs := make(map[string]struct{})
 
-	githubLinkRegex := regexp.MustCompile(`https?://github\.com[-a-zA-Z0-9@:%._\+~#=/]*`)
+	githubLinkRegex := regexp.MustCompile(`https?://(?:[a-zA-Z0-9-]+\.)*github(?:usercontent)?\.com[-a-zA-Z0-9@:%._\+~#=/]*`)
 	issuesPRRegex := regexp.MustCompile(`/(?:issues|pull)/[0-9]+`)
 	componentsRegex := regexp.MustCompile(`/releases/(?:v|tag/v)?[0-9]+\.[0-9]+\.[0-9]+/.*-components\.ya?ml$`)
 


### PR DESCRIPTION
This PR extends the release workflow to bump the Turtles version everywhere on each release. It also adds a new workflow that can update dependency versions based on input: 
<img width="318" alt="Screenshot 2025-06-09 at 15 56 48" src="https://github.com/user-attachments/assets/10f8e72c-2faf-4a82-85f9-d5a0557e67ed" />
<img width="931" alt="Screenshot 2025-06-09 at 16 00 43" src="https://github.com/user-attachments/assets/f2b349a6-31bb-4103-869b-0b32d7025e6a" />

The new workflow can run as a pre-release so we can bump dependencies before releasing the new Turtles version. I will add it to the release documentation.

I also fixed all broken/unversioned URLs.
Fixes https://github.com/rancher/turtles-docs/issues/144
