### PR TITLE
Unify cluster class setup via examples

### DIFF
--- a/docs/next/modules/en/pages/user/clusterclass.adoc
+++ b/docs/next/modules/en/pages/user/clusterclass.adoc
@@ -321,20 +321,7 @@ Azure RKE2::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/rke2/clusterclass-rke2-example.yaml
-----
-+
-* Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
-For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
-+
-We can do this automatically at Cluster creation using the https://rancher.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/azure/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+go run github.com/rancher/turtles/examples@latest -r azure-rke2 | kubectl apply -f -
 ----
 +
 * Create the Azure Cluster from the example ClusterClass +
@@ -388,7 +375,7 @@ Azure AKS::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/aks/clusterclass-aks-example.yaml
+go run github.com/rancher/turtles/examples@latest -r azure-aks | kubectl apply -f -
 ----
 +
 * Create the Azure AKS Cluster from the example ClusterClass +
@@ -435,20 +422,7 @@ Azure Kubeadm::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/kubeadm/clusterclass-kubeadm-example.yaml
-----
-+
-* Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
-For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
-+
-We can do this automatically at Cluster creation using the https://rancher.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/azure/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+go run github.com/rancher/turtles/examples@latest -r azure-kubeadm | kubectl apply -f -
 ----
 +
 * Create the Azure Cluster from the example ClusterClass +
@@ -497,22 +471,7 @@ AWS Kubeadm::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/aws/kubeadm/clusterclass-kubeadm-example.yaml
-----
-+
-* For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
-* The https://github.com/kubernetes/cloud-provider-aws[Cloud Controller Manager AWS] will need to be installed on each downstream Cluster for the nodes to be functional. +
-* Additionally, we will also enable https://github.com/kubernetes-sigs/aws-ebs-csi-driver[AWS EBS CSI Driver]. +
-+
-We can do this automatically at Cluster creation using the https://rancher.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-The `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. This will take care of deploying Calico, the EBS CSI Driver, and the AWS Cloud Controller Manager in the workload cluster. +
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/aws/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/aws/calico/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/aws/helm-chart.yaml
+go run github.com/rancher/turtles/examples@latest -r aws-kubeadm | kubectl apply -f -
 ----
 +
 * Create the AWS Cluster from the example ClusterClass +
@@ -568,21 +527,7 @@ You can follow the steps in the https://github.com/rancher/cluster-api-provider-
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
-----
-+
-* The https://github.com/kubernetes/cloud-provider-aws[Cloud Controller Manager AWS] will need to be installed on each downstream Cluster for the nodes to be functional. +
-* Additionally, we will also enable https://github.com/kubernetes-sigs/aws-ebs-csi-driver[AWS EBS CSI Driver]. +
-+
-We can do this automatically at Cluster creation using the https://rancher.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. This will take care of deploying the AWS Cloud Controller Manager and the EBS CSI Driver in the workload cluster. +
-The CNI selection can instead be configured using Cluster variables and it will be provided by RKE2. +
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/aws/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/aws/helm-chart.yaml
+go run github.com/rancher/turtles/examples@latest -r aws-rke2 | kubectl apply -f -
 ----
 +
 * Create the AWS Cluster from the example ClusterClass +
@@ -635,22 +580,11 @@ Docker Kubeadm::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/kubeadm/clusterclass-docker-kubeadm.yaml
-----
-+
-* For this example we are also going to install Calico as the default CNI.
-+
-We can do this automatically at Cluster creation using the https://rancher.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+go run github.com/rancher/turtles/examples@latest -r docker-kubeadm | kubectl apply -f -
 ----
 +
 * Create the Docker Kubeadm Cluster from the example ClusterClass +
-+ 
++
 Note that some variables are left to the user to substitute. +
 +
 [source,yaml]
@@ -688,25 +622,7 @@ Docker RKE2::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
-----
-+
-* For this example we are also going to install Calico as the default CNI.
-+
-We can do this automatically at Cluster creation using the https://rancher.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
-----
-+
-* Create the LoadBalancer ConfigMap for Docker RKEv2 Cluster +
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/lb/docker/configmap.yaml
+go run github.com/rancher/turtles/examples@latest -r docker-rke2 | kubectl apply -f -
 ----
 +
 * Create the Docker Kubeadm Cluster from the example ClusterClass +
@@ -749,32 +665,11 @@ spec:
 
 vSphere Kubeadm::
 +
-* A vSphere ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
+* A vSphere Kubeadm ClusterClass and associated applications can be applied using the examples tool:
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/vsphere/kubeadm/clusterclass-kubeadm-example.yaml
-----
-+
-* Additionally, the https://github.com/kubernetes/cloud-provider-vsphere[vSphere Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
-The https://github.com/kubernetes-sigs/vsphere-csi-driver[Container Storage Interface (CSI) driver for vSphere] will be used as storage solution. +
-Finally, for this example we are going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
-+
-We can install all applications automatically at Cluster creation using the https://rancher.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/vsphere/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
-----
-+
-Since the vSphere CSI driver is not packaged in Helm, we are going to include its entire manifest in a Fleet Bundle, that will be applied to the downstream Cluster.
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/vsphere/bundle.yaml
+go run github.com/rancher/turtles/examples@latest -r vsphere-kubeadm | kubectl apply -f -
 ----
 +
 * Cluster configuration
@@ -908,32 +803,11 @@ spec:
 
 vSphere RKE2::
 +
-* A vSphere ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
+* A vSphere RKE2 ClusterClass and associated applications can be applied using the examples tool:
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
-----
-+
-* Additionally, the https://github.com/kubernetes/cloud-provider-vsphere[vSphere Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
-The https://github.com/kubernetes-sigs/vsphere-csi-driver[Container Storage Interface (CSI) driver for vSphere] will be used as storage solution. +
-Finally, for this example we are going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
-+
-We can install all applications automatically at Cluster creation using the https://rancher.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/vsphere/helm-chart.yaml
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
-----
-+
-Since the vSphere CSI driver is not packaged in Helm, we are going to include its entire manifest in a Fleet Bundle, that will be applied to the downstream Cluster.
-+
-[source,bash]
-----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/vsphere/bundle.yaml
+go run github.com/rancher/turtles/examples@latest -r vsphere-rke2 | kubectl apply -f -
 ----
 +
 * Cluster configuration

--- a/replace-rules.json
+++ b/replace-rules.json
@@ -19,6 +19,11 @@
         "name": "Update version in component table description",
         "pattern": "This table lists the version of the components installed with the latest version `v[0-9]+\\.[0-9]+\\.[0-9]+` of \\{product_name\\}:",
         "replacement": "This table lists the version of the components installed with the latest version `%s` of {product_name}:"
+      },
+      {
+        "name": "Update examples tool tag",
+        "pattern": "go run github\\.com/rancher/turtles/examples@latest",
+        "replacement": "go run github.com/rancher/turtles/examples@%s"
       }
     ]
   }


### PR DESCRIPTION
Update documentation to use the `go run github.com/rancher/turtles/examples@latest` command for applying ClusterClasses and associated applications, specifically in the vSphere sections of `docs/next/modules/en/pages/user/clusterclass.adoc`.

Added a new rule to `replace-rules.json` to update the examples tool tag from `@latest` to `@<tag>`, enabling automation of pre-release tag synchronization.

Fixes https://github.com/rancher/turtles/issues/1459