### PR TITLE
fix: broken link to capz docs

### DIFF
--- a/docs/next/modules/en/pages/user/clusterclass.adoc
+++ b/docs/next/modules/en/pages/user/clusterclass.adoc
@@ -15,7 +15,7 @@ Azure::
 +
 To prepare the management Cluster, we are going to install the https://capz.sigs.k8s.io/[Cluster API Provider Azure], and create a https://capz.sigs.k8s.io/topics/identities#service-principal[ServicePrincipal] identity to provision a new Cluster on Azure. +
 Before we start, a ServicePrincipal needs to be created, with at least Contributor access to an Azure subscription. +
-Refer to the https://capz.sigs.k8s.io/getting-started#setting-up-your-azure-environment[CAPZ documentation] for more details. +
+Refer to the https://capz.sigs.k8s.io/topics/identities[CAPZ documentation] for more details. +
 +
 * Provider installation
 +

--- a/docs/v0.18/modules/en/pages/user/clusterclass.adoc
+++ b/docs/v0.18/modules/en/pages/user/clusterclass.adoc
@@ -15,7 +15,7 @@ Azure::
 +
 To prepare the management Cluster, we are going to install the https://capz.sigs.k8s.io/[Cluster API Provider Azure], and create a https://capz.sigs.k8s.io/topics/identities#service-principal[ServicePrincipal] identity to provision a new Cluster on Azure. +
 Before we start, a ServicePrincipal needs to be created, with at least Contributor access to an Azure subscription. +
-Refer to the https://capz.sigs.k8s.io/getting-started#setting-up-your-azure-environment[CAPZ documentation] for more details. +
+Refer to the https://capz.sigs.k8s.io/topics/identities[CAPZ documentation] for more details. +
 +
 * Provider installation
 +

--- a/docs/v0.19/modules/en/pages/user/clusterclass.adoc
+++ b/docs/v0.19/modules/en/pages/user/clusterclass.adoc
@@ -15,7 +15,7 @@ Azure::
 +
 To prepare the management Cluster, we are going to install the https://capz.sigs.k8s.io/[Cluster API Provider Azure], and create a https://capz.sigs.k8s.io/topics/identities#service-principal[ServicePrincipal] identity to provision a new Cluster on Azure. +
 Before we start, a ServicePrincipal needs to be created, with at least Contributor access to an Azure subscription. +
-Refer to the https://capz.sigs.k8s.io/getting-started#setting-up-your-azure-environment[CAPZ documentation] for more details. +
+Refer to the https://capz.sigs.k8s.io/topics/identities[CAPZ documentation] for more details. +
 +
 * Provider installation
 +

--- a/docs/v0.20/modules/en/pages/user/clusterclass.adoc
+++ b/docs/v0.20/modules/en/pages/user/clusterclass.adoc
@@ -15,7 +15,7 @@ Azure::
 +
 To prepare the management Cluster, we are going to install the https://capz.sigs.k8s.io/[Cluster API Provider Azure], and create a https://capz.sigs.k8s.io/topics/identities#service-principal[ServicePrincipal] identity to provision a new Cluster on Azure. +
 Before we start, a ServicePrincipal needs to be created, with at least Contributor access to an Azure subscription. +
-Refer to the https://capz.sigs.k8s.io/getting-started#setting-up-your-azure-environment[CAPZ documentation] for more details. +
+Refer to the https://capz.sigs.k8s.io/topics/identities[CAPZ documentation] for more details. +
 +
 * Provider installation
 +


### PR DESCRIPTION
# Description

The current link to CAPZ documentation on how to set up permissions for the provider has been removed. The former site is now a specific guide on how to create a CAPI management cluster on AKS. This PR adds a link to the guide on how to use the different identity methods.