### PR TITLE
Remove warning for Kubeadm controlplane replica

### DIFF
--- a/docs/next/modules/en/pages/user/clusterclass.adoc
+++ b/docs/next/modules/en/pages/user/clusterclass.adoc
@@ -410,8 +410,7 @@ spec:
 
 [WARNING]
 ====
-- Examples using `HelmApps` need at least Rancher `v2.11`, or otherwise Fleet `v0.12` or higher.
-- Currently, we only support initial provisioning with 1 control plane replica for Kubeadm providers; this can be later scaled up, https://github.com/rancher/turtles/issues/1402[refer]. +
+Examples using `HelmApps` need at least Rancher `v2.11`, or otherwise Fleet `v0.12` or higher.
 ====
 
 [tabs]


### PR DESCRIPTION
Reverts the warning part of https://github.com/rancher/turtles-docs/pull/313, since https://github.com/rancher/turtles/issues/1402 is fixed