### PR TITLE
Update AWSClusterStaticIdentity to allow all namespaces

### DIFF
--- a/docs/next/modules/en/pages/operator/airgapped.adoc
+++ b/docs/next/modules/en/pages/operator/airgapped.adoc
@@ -50,7 +50,7 @@ spec:
 
 == How to mirror CAPI Provider OCI artifact
 
-You mirror OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You mirror OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Install the ORAS (OCI Registry As Storage) CLI tool to manage OCI artifacts. Follow the installation instructions at: https://oras.land/docs/installation
 
@@ -116,7 +116,7 @@ kubectl apply -f capz-provider-oci.yaml
 Using kubectl operator::
 +
 ====
-You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Install https://cluster-api-operator.sigs.k8s.io/03_topics/03_plugin/01_installation[cluster-api-operator] plugin for `kubectl`
 
@@ -177,7 +177,7 @@ kubectl operator publish -u ${PROD_REGISTRY}:${RELEASE_TAG} infrastructure-compo
 Using Oras::
 +
 ====
-You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Clone the official https://github.com/kubernetes-sigs/cluster-api-provider-azure/[Azure CAPI Provider repository] and navigate to the project directory
 

--- a/docs/next/modules/en/pages/user/clusterclass.adoc
+++ b/docs/next/modules/en/pages/user/clusterclass.adoc
@@ -186,9 +186,7 @@ metadata:
   name: cluster-identity
 spec:
   secretRef: <AWS_IDENTITY_SECRET_NAME>
-  allowedNamespaces:
-    selector:
-      matchLabels: {}
+  allowedNamespaces: {}
 ----
 
 GCP::

--- a/docs/v0.21/modules/en/pages/operator/airgapped.adoc
+++ b/docs/v0.21/modules/en/pages/operator/airgapped.adoc
@@ -50,7 +50,7 @@ spec:
 
 == How to mirror CAPI Provider OCI artifact
 
-You mirror OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You mirror OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Install the ORAS (OCI Registry As Storage) CLI tool to manage OCI artifacts. Follow the installation instructions at: https://oras.land/docs/installation
 
@@ -116,7 +116,7 @@ kubectl apply -f capz-provider-oci.yaml
 Using kubectl operator::
 +
 ====
-You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Install https://cluster-api-operator.sigs.k8s.io/03_topics/03_plugin/01_installation[cluster-api-operator] plugin for `kubectl`
 
@@ -177,7 +177,7 @@ kubectl operator publish -u ${PROD_REGISTRY}:${RELEASE_TAG} infrastructure-compo
 Using Oras::
 +
 ====
-You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Clone the official https://github.com/kubernetes-sigs/cluster-api-provider-azure/[Azure CAPI Provider repository] and navigate to the project directory
 

--- a/docs/v0.22/modules/en/pages/operator/airgapped.adoc
+++ b/docs/v0.22/modules/en/pages/operator/airgapped.adoc
@@ -50,7 +50,7 @@ spec:
 
 == How to mirror CAPI Provider OCI artifact
 
-You mirror OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You mirror OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Install the ORAS (OCI Registry As Storage) CLI tool to manage OCI artifacts. Follow the installation instructions at: https://oras.land/docs/installation
 
@@ -116,7 +116,7 @@ kubectl apply -f capz-provider-oci.yaml
 Using kubectl operator::
 +
 ====
-You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Install https://cluster-api-operator.sigs.k8s.io/03_topics/03_plugin/01_installation[cluster-api-operator] plugin for `kubectl`
 
@@ -177,7 +177,7 @@ kubectl operator publish -u ${PROD_REGISTRY}:${RELEASE_TAG} infrastructure-compo
 Using Oras::
 +
 ====
-You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Clone the official https://github.com/kubernetes-sigs/cluster-api-provider-azure/[Azure CAPI Provider repository] and navigate to the project directory
 

--- a/docs/v0.23/modules/en/pages/operator/airgapped.adoc
+++ b/docs/v0.23/modules/en/pages/operator/airgapped.adoc
@@ -50,7 +50,7 @@ spec:
 
 == How to mirror CAPI Provider OCI artifact
 
-You mirror OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You mirror OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Install the ORAS (OCI Registry As Storage) CLI tool to manage OCI artifacts. Follow the installation instructions at: https://oras.land/docs/installation
 
@@ -116,7 +116,7 @@ kubectl apply -f capz-provider-oci.yaml
 Using kubectl operator::
 +
 ====
-You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Install https://cluster-api-operator.sigs.k8s.io/03_topics/03_plugin/01_installation[cluster-api-operator] plugin for `kubectl`
 
@@ -177,7 +177,7 @@ kubectl operator publish -u ${PROD_REGISTRY}:${RELEASE_TAG} infrastructure-compo
 Using Oras::
 +
 ====
-You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config.yaml
+You can build OCI artifacts for any CAPI Provider listed in the Rancher Turtles configuration: https://github.com/rancher/turtles/blob/main/internal/controllers/clusterctl/config-default.yaml
 
 Clone the official https://github.com/kubernetes-sigs/cluster-api-provider-azure/[Azure CAPI Provider repository] and navigate to the project directory
 


### PR DESCRIPTION
Needed for CAPA v2.9.0 version.