### PR TITLE
Correct CAPI version used in v0.18

### DIFF
--- a/docs/v0.18/modules/en/pages/tutorials/quickstart.adoc
+++ b/docs/v0.18/modules/en/pages/tutorials/quickstart.adoc
@@ -47,7 +47,7 @@ If you're customizing the installation parameters, please make sure that you are
 | `v0.17.1`
 
 | Cluster API
-| `v1.9.6`
+| `v1.9.5`
 
 | Cluster API Provider RKE2
 | `v0.13.0`


### PR DESCRIPTION
FYI the correct version is `v1.9.5`, not `v1.9.6`. See config: https://github.com/rancher/turtles/blob/release-0.18/internal/controllers/clusterctl/config.yaml#L14

I did track down [this PR](https://github.com/rancher/turtles/pull/1159/files) that bumped the cluster-api go dependency, probably it's where v1.9.6 came from. 