### PR TITLE
Add EKS ClusterClass doc

### DIFF
--- a/docs/next/modules/en/pages/user/clusterclass.adoc
+++ b/docs/next/modules/en/pages/user/clusterclass.adoc
@@ -651,6 +651,67 @@ spec:
         name: md-0
         replicas: 1
 ----
+AWS EKS::
++
+* An AWS EKS ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
++
+[tabs]
+=======
+
+CLI::
++
+An AWS EKS ClusterClass and associated applications can be applied using the examples tool:
++
+[source,bash]
+----
+go run github.com/rancher/turtles/examples@v0.23.0 -r aws-eks | kubectl apply -f -
+----
+
+kubectl::
++
+* Alternatively, you can apply the AWS EKS ClusterClass directly using kubectl:
++
+[source,bash]
+----
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.23.0/examples/clusterclasses/aws/eks/clusterclass-eks-example.yaml
+----
+=======
++
+* Create the AWS Cluster from the example ClusterClass +
++
+Note that some variables are left to the user to substitute. +
++
+[source,yaml]
+----
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster-api.cattle.io/rancher-auto-import: "true"
+  name: aws-quickstart
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  topology:
+    class: aws-eks-example
+    variables:
+    - name: region
+      value: eu-west-2
+    - name: sshKeyName
+      value: <AWS_SSH_KEY_NAME>
+    - name: instanceType
+      value: <AWS_NODE_MACHINE_TYPE>
+    - name: awsClusterIdentityName
+      value: cluster-identity
+    version: v1.31.0
+    workers:
+      machineDeployments:
+      - class: default-worker
+        name: md-0
+        replicas: 1
+----
 
 AWS Kubeadm::
 +

--- a/docs/next/modules/en/pages/user/clusterclass.adoc
+++ b/docs/next/modules/en/pages/user/clusterclass.adoc
@@ -664,7 +664,7 @@ An AWS EKS ClusterClass and associated applications can be applied using the exa
 +
 [source,bash]
 ----
-go run github.com/rancher/turtles/examples@v0.23.0 -r aws-eks | kubectl apply -f -
+go run github.com/rancher/turtles/examples@main -r aws-eks | kubectl apply -f -
 ----
 
 kubectl::
@@ -673,7 +673,7 @@ kubectl::
 +
 [source,bash]
 ----
-kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/v0.23.0/examples/clusterclasses/aws/eks/clusterclass-eks-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/main/examples/clusterclasses/aws/eks/clusterclass-eks-example.yaml
 ----
 =======
 +


### PR DESCRIPTION
To be merged after https://github.com/rancher/turtles/pull/1712 is merged.

I am not sure about the location of the document, I added it to next, but it is using the tag `v0.23.0` to fetch the ClusterClass which will not work. This feature will be available in `v0.25.0` since [v0.24.0](https://github.com/rancher/turtles/releases/tag/v0.24.0) was released earlier this week.

----------
_Preview Image:_
<img width="1004" height="1142" alt="image" src="https://github.com/user-attachments/assets/355a3a02-db28-4142-9dac-e6499a44c604" />
